### PR TITLE
Fix for Size and Symbols not found issues.

### DIFF
--- a/make.py
+++ b/make.py
@@ -49,7 +49,7 @@ def main(options):
     make_debug = False
     make_task = ''
     ios_archs = ['arm64', 'arm', 'x86', 'x64']
-    ios_configurations = ['debug']
+    ios_configurations = ['release'] #debug
 
     # show all params for debug
     if ('--debug' in options and options['--debug']) or ('-d' in options and options['-d']):
@@ -151,12 +151,19 @@ def run_task_install_ios(ios_archs, ios_configurations):
         # archs
         for arch in ios_archs:
             folder = os.path.join('pdfium', 'out', '{0}-{1}'.format(config, arch), 'obj', '**', '*.a')
-            files = glob.glob(folder, recursive=True)            
+            # skia_shared and pdfium_base have only a few object files and due to that there is no point in creating their own .a files.
+            # We can link the .o files directly.
+            skia_o=os.path.join('pdfium', 'out', '{0}-{1}'.format(config, arch), 'obj', 'third_party', 'skia_shared', '*.o')
+            base_o=os.path.join('pdfium', 'out', '{0}-{1}'.format(config, arch), 'obj', 'third_party', 'pdfium_base', '*.o')
+            files = glob.glob(folder, recursive=True)
+            files.append(skia_o)
+            files.append(base_o)
             files_str = ' '.join(files)
 
             lib_file_out = os.path.join('build', 'ios', config, 'libpdfium_{0}.a'.format(arch))
 
-            command = ' '.join(['libtool', '-static', files_str, '-o', lib_file_out])
+            # We have removed symbols to squeeze final results. -no_warning_for_no_symbols will save us from useless warnings.
+            command = ' '.join(['libtool', '-static -no_warning_for_no_symbols', files_str, '-o', lib_file_out])
             call(command, shell=True)
 
         # universal
@@ -194,7 +201,8 @@ def run_task_build_ios(ios_archs, ios_configurations):
             debug('Generating files to arch "{0}" and configuration "{1}"...'.format(arch, config))
 
             arg_is_debug = ('true' if config == 'debug' else 'false')
-            args = 'target_os="ios" target_cpu="{0}" use_goma=false is_debug={1} pdf_use_skia=false pdf_use_skia_paths=false pdf_enable_xfa=false pdf_enable_v8=false pdf_is_standalone=true is_component_build=false clang_use_chrome_plugins=false ios_enable_code_signing=false enable_ios_bitcode=true'.format(arch, arg_is_debug)
+            # Adding symbol_level=0 will squeeze the final result significantly. But it is needed for debug builds.
+            args = 'target_os="ios" target_cpu="{0}" use_goma=false is_debug={1} pdf_use_skia=false pdf_use_skia_paths=false pdf_enable_xfa=false pdf_enable_v8=false pdf_is_standalone=true is_component_build=false clang_use_chrome_plugins=false ios_enable_code_signing=false enable_ios_bitcode=true {2}'.format(arch, arg_is_debug, 'symbol_level=0' if arg_is_debug else '')
             command = ' '.join([gn_tool, 'gen', 'out/{0}-{1}'.format(config, arch), '--args=\'{0}\''.format(args)])
             call(command, shell=True)
 


### PR DESCRIPTION
This is to fix the issued mentioned in the following issue as the first and third problem:

https://github.com/prsolucoes/mobile-pdfium/issues/1

With this change I am able to achieve a 38 Mb universal .a file rather than a gigabyte file.
Linker errors; which were thrown during build of application using this library; are also fixed.

Other two problems mentioned in the issue are not related to the project I am working on. I will not be able to work on them.