### PR TITLE
Hienpn/lp 203 core customize pdfium sdk

### DIFF
--- a/docker/android/Dockerfile
+++ b/docker/android/Dockerfile
@@ -54,7 +54,7 @@ RUN mkdir /build
 WORKDIR /build
 RUN gclient config --custom-var checkout_configuration=minimal --unmanaged https://pdfium.googlesource.com/pdfium.git
 RUN echo "target_os = [ 'android' ]" >> .gclient
-RUN gclient sync -r origin/chromium/7623 --no-history --shallow
+RUN gclient sync -r origin/chromium/7623 --no-history --shallow -j 4 || gclient sync -r origin/chromium/7623 --no-history --shallow -j 1
 
 # pdfium reset and clean directories
 RUN git -C /build/pdfium reset --hard

--- a/extras/wasm/node/index.js
+++ b/extras/wasm/node/index.js
@@ -1,2 +1,0 @@
-import pdfium from './pdfium.js';
-import pdfiumModule from './pdfium.wasm';

--- a/extras/wasm/node/package.json
+++ b/extras/wasm/node/package.json
@@ -1,16 +1,16 @@
 {
-    "name": "pdfium",
-    "scripts": {
-        "build": "webpack",
-        "serve": "http-server dist/",
-        "start": "npm run build && npm run serve"
-    },
-    "devDependencies": {
-        "exports-loader": "0.7.0",
-        "file-loader": "1.1.11",
-        "http-server": "0.12.3",
-        "webpack": "4.43.0",
-        "webpack-cli": "4.4.0",
-        "html-webpack-plugin": "4.5.1"
-    }
+  "name": "pdfium",
+  "scripts": {
+    "build": "webpack",
+    "serve": "http-server dist/",
+    "start": "npm run build && npm run serve"
+  },
+  "devDependencies": {
+    "exports-loader": "0.7.0",
+    "file-loader": "1.1.11",
+    "http-server": "0.12.3",
+    "webpack": "4.43.0",
+    "webpack-cli": "4.4.0",
+    "html-webpack-plugin": "4.5.1"
+  }
 }

--- a/extras/wasm/node/webpack.config.js
+++ b/extras/wasm/node/webpack.config.js
@@ -1,7 +1,7 @@
 const webpack = require("webpack");
 const path = require("path");
 
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 module.exports = {
   mode: "development",
@@ -9,23 +9,23 @@ module.exports = {
   entry: "./index.js",
   output: {
     path: path.resolve(__dirname, "dist"),
-    filename: "bundle.js"
+    filename: "bundle.js",
   },
   // This is necessary due to the fact that emscripten puts both Node and web
   // code into one file. The node part uses Node’s `fs` module to load the wasm
   // file.
   // Issue: https://github.com/kripken/emscripten/issues/6542.
   node: {
-    "fs": "empty"
+    fs: "empty",
   },
   module: {
     rules: [
-      // Emscripten JS files define a global. With `exports-loader` we can 
+      // Emscripten JS files define a global. With `exports-loader` we can
       // load these files correctly (provided the global’s name is the same
       // as the file name).
       {
         test: /pdfium\.js$/,
-        loader: "exports-loader"
+        loader: "exports-loader",
       },
       // wasm files should not be processed but just be emitted and we want
       // to have their public URL.
@@ -35,10 +35,10 @@ module.exports = {
         loader: "file-loader",
         options: {
           publicPath: "dist/",
-          name: '[path][name].[ext]',
-        }
-      }
-    ]
+          name: "[path][name].[ext]",
+        },
+      },
+    ],
   },
   plugins: [new HtmlWebpackPlugin()],
 };

--- a/extras/wasm/template/index.html
+++ b/extras/wasm/template/index.html
@@ -1,1222 +1,1321 @@
 <!DOCTYPE html>
 <html>
-
-<head>
+  <head>
     <meta charset="utf-8">
 
-    <meta name="viewport"
-        content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height" />
+    <meta
+      name="viewport"
+      content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height"
+    >
 
     <title>PDFium PDF Viewer</title>
-    <meta name="description"
-        content="Quickly view your PDF files with the PDFium PDF Viewer. Easy, fast, and secure, all within your browser.">
-    <meta name="keywords"
-        content="pdfium, pdf viewer, view pdf, pdf reader, browser, webassembly, fast pdf, secure pdf">
+    <meta
+      name="description"
+      content="Quickly view your PDF files with the PDFium PDF Viewer. Easy, fast, and secure, all within your browser."
+    >
+    <meta
+      name="keywords"
+      content="pdfium, pdf viewer, view pdf, pdf reader, browser, webassembly, fast pdf, secure pdf"
+    >
 
     <meta property="og:title" content="PDFium PDF Viewer">
-    <meta property="og:description"
-        content="Quickly view your PDF files with the PDFium PDF Viewer. Easy, fast, and secure, all within your browser.">
-    <meta property="og:image" content="https://pdfium-lib.s3.amazonaws.com/others/logo.png">
+    <meta
+      property="og:description"
+      content="Quickly view your PDF files with the PDFium PDF Viewer. Easy, fast, and secure, all within your browser."
+    >
+    <meta
+      property="og:image"
+      content="https://pdfium-lib.s3.amazonaws.com/others/logo.png"
+    >
     <meta property="og:url" content="https://pdfviewer.github.io">
     <meta property="og:type" content="website">
 
-    <link rel="shortcut icon"
-        href="data:image/x-icon;base64,UklGRtASAABXRUJQVlA4TMMSAAAv/8F/EH+HoG3blD/pSG32UxAQFPk/moCg4P/oBAJJavtDbbRtG40NOT0jwgYBAkDAAQFAArDLICAARjA1HRADCqxhf04whCEM6ImQMVZQZtiCTlFLXHTwzajPNiRT6yOoEadHVvdlHLEhZO3/Bn1WkWhFmstFBanIWjp4GADaldJs2641A0NREAULii0ae+8pGsXexd6wlzD2hmLXSGJNQdMsxF4wWC+97JpgwBpFbFhADG3KWfePEGbW2mc4M+tuRPR/ArDc/+X+L/d/uf/L/V/u/3L//2+/trtnjx49e7dY4mzXv587vJ0FSvRvFfe7TdSyt/euAG5XW/xUyrST/fyA1jIpU8K0Y62BMcD6Vrz+6gbMlbcUilZxvD8o2Oa5XN1rA4quKRaqw6GgbPO/RGqTCRQO2i1P2jJQfIM4JYDyicKUBDo8LkpXLXqo8lKQ8uqDLscKUhzoNF2MMvz0EitGg0GvFQuE6Dbo95gQjdeRVYZeBejoMxlKBB2Hy1BLPcF7CcoAXf8tQau4Qhv5s6RJUAeOlhvPvdDw6TiOqwKUDfQRJzQs+UIzuisCtIfhBrr4hu6mAE2mi0dXM+gyBKgRWeX3Lp2jeyY/b4B8Drr8G12B/KTQ3XRtO1lFlN+VZJGaawlk9QVoGNlodH0m2acC9DHZNjeGksXIT5GZ7Kobn5LNk58MoDblu9GQbIv8HCZrgG6Gkh2Vn0Syfm7kA/lf8vMlmdWNh3Tv5Wcw2TY3LpBFoPy2JzvpRjJZWwGqRXbXjUSyYfKj+ZMVuLGAbL785AB1OLo5mmyr/Nwna+5ON7Jj8nOFLNqdhmRp8nOSbJQbWiBZjvwkk81yIxuoAzT52Um2zI0bZI1QfreQrXfjAFkPAdpIttWNr8hiBWgVWZIbM8hWCFA82S9u9Cb7UYCWkO1zoyHZeQFaRJbsmt1CliVAC9V4CNQBTgFaTLbXtRNkjVCAl5L97FoiWV8JSiD7wbVpZFYJWku2xbUvyLZL0Ddk61yrQXZagn4gW+rSWyB/JkF7yWa6dIEsRJOgE2QjXfqOrD1K8EWyni7FkY0ToQyyVi71IFsrQtlkNVzRIsiOipDDTGW2u/AcyP8WIaxGBVkunCQLdspQK7L/uLCBrD3KcB+y3S6MIYsVoilkq1xoSva1EK0mm1BavpnsrBDtJutS2mUgzxGiy2ThpW0ni0IhfkUGr0qZRDZAirQwsrOltCFbLkXYgWxLSYUWskNiNI5sSklXgPyJGK0j61jSZrIITYyOkgU7ShhL1gvF+DEZpJfQiGyJHGmhZD9+kAvkh+QIPyWb9UEq3VNBmk3W/oMEskgU5J1klkJE7E02SJLSyOASojOMbI0k2YPINiJmAPkpScIuZIMQk8hM70QpjixCw1iyZijKe8ggAxuTTZKlx3Q7soH8B1nSapANP0CXIUs4hKz6l2SVncK0iQyCyPqgMF+no18lTfYQ5c5LE/ZSLaBQnNaq1gXF+bJqi+XJHqpYijxhP7XM7wQqUa22KNDpas2TKK2mUsclCieoZM4VqX0qtUeRfmNWaJFMYSeFUoUqQR1LvlDdVKcbCrUWqcwqqcIpylwVq+OqhDnEqrCiIsNQrmMU+V6w9iqSKVh5gUo0QskepEScaO1W4qRovQ9WIKhAtHC4Ar1Rto8qsFW4isP5HgsXzmJrgtJ9g22+eGnNuC6IFyYyhTvk63UAzzgU8OE8+yXsLEvgewnTmnD0QxHfzPGDjL3j+EXGsAJDZ03G6jBAioi9MHO00yRsC7AelLAuPB/b5SsTmJPkaz1XrXzp0ppywWrpugXsodnCZeWDqbJlq6qAOU20joGK3TXJilEC9gtWTqAadfLlagcoGi9X7VQJfChVf4KyfTShmq0OHJSpgjCFovJE6mdQ2SpSnyllviFQGaB2a7s8xSkGG8UpP0y14IfSlATKf6EJUzv14DtZugo6DM0SpbF6gF6aIL0K0AX8IEirgb4/S2imGNlq0YXl9+KA7k4p2gf0cfgwiAM2S1FnhjuIa1iC78rQVaDvhoi2ZhzQ3iZCIxiSEREvmThguQRl+dFF2j7AWSx+lwVoIdCvwBLzojigfp745IXR+T8vCVNYYLz4fA30w7H08SywT3jsdRguuZATyRKWKTv7gL695gIeYYEudsnR2jD8ii6PYYFlknMK6COLXcuJZDGdFpxeDKvQzRMsUCNbbG4BfdBrdzCWBXo6pSaGYQq6/a4uC6wRmnsmhgz38LyJxe+8zMQCfT+knMcCkS8lJsvCcI6kqDkLdHcIzGygb6uR4O1AFlgmLy+DGPYicSIPpIjLAqCvZ6dyRvNUfiwsrysybEPy5xEs0KZQVpYCfUQ+HR7jgVhNUnJCGVYi52we+FZS4oE+JIelsAWP5ZKc5FRimI+8dyqwQORzMYkH+sDnTLiLB7oUC0lOJYYZyK2N5oEpQrIE6P0z2fB9Ix7YLiKvKzJMQAXTgnj8z0nIfKA331UBk3gg/JF8PA9mGIVKauN4oHmeeMwCelOGGvhPUx4Y6BSOTAtDDKp6N4QHFgtHLDCmKYPJTPCLaNwxMwxFha1MARclYxgwpqlk+4wHqj6Si+vAOBSVfhHJA01yxSKawXRbLbzozwPRNqE4BYzDUfVtTDBFEwmtHYP5jnLaRCbYIBLJwDgW1S/swAS/CURxAwa/BzrApzWYgi7JwxZgnIy6/E8AD0Q8kIbcCIaALH1gEhM0eC0MS4AxDvUaxwSd8kUhK4ihYrZu7NFMMMghCWOBMR71m/MxE8zQ5OAmMIa/0xHeC2OCVW8f/XH+RPLObRtXLVswZ/bMGR/Ots5fmrBha9K+4+f+eJTr9I1pn3NsQl2n+jEpaQ5v3DVm9tqfTt0r8GUdBMaoQn3hdv25XLXdsAXfnc5y+qCKPuLYhXqP8ySlBrccviI5w+ZT+goYmzr0lXs5yeqBSra0HLvpTK6P6FUljqOo1/dXkqzRtcDzNxix6WKh72cqMHbVdOC8l7xsYH0oSy0drAdf+3TSzBxXUe28i9umdAqEsrnZrIO5vhqtKzAOR3WzU1YPawBlvLlj/BWnLyYZGAMeqZF9ImFgFBjFarFHC30t+bU55iL7+7Prh0SB0QwZebjIp7IcGCvnsGh3kiY3N4NBrTz1suYzeRzEkYjk+WdX960CBrdJYo6PZAgwNiymeXtkbkd/MMTBkzN8IanAeRjdf7V/VnMw1H0u+DyKG3F009zIPRzXHAx41/M+jnXAaPoDXSw8taidGYx67zRfRlZFjklYsnb7q+ggMPSmSa98F8OAMfTlB2/3TYgEL7DyZqeP4nfgXI/arVVdzOAtfnrfJ1HYkKPG3thI8CqDt2s+iATwrgfm+BzuB3pZUO8PH4MWDV53cLJvYQ8Y2UW7dmxKWDRj7IDPm0V6EoDVmg8hp7qhiUhDF7Xcu+d2b7QObV/VE8A0h+9gKpTFwc0GWTcfT8/D66FcEP6nC67mZxxNnN6jlr4gxuYruAhlq1+DfvO+P5PlxNLPBXFBlVsUpb67snNOdFXdwMBi30BxkzLD0jRmRXJ6Mbp/3J8LKl+nK1F7dmx536q6gEE2n8BKKAvrDVyanGFD8n0mLgi7xFOi9vfumS1NysFopw/gboCHC+k8dcelPOROYoOQ83wl5hyb18akFli9P+fn4Lmj+sUfeOhENRPZIDhVjQ/f7p8cpRJs9vZs/cEz1x265uQrVHoVGwQcVgYRtT8TWqtjTvXq0qzggWsOWpP6FtXXFrOB368KffhwVWNFoEqm1/Z2SxvwtMGfLTiQhXrV4tjAtE0tRO3yxCAloKPNK3OeHhkInjVqxDc3bKhrbSobwEpNLUR8s6a6CrDEC3ux5iPwqM2m73mCHtA5gQ/inKohFm6JVMB8xcty/j7EHzynqY318Bv0lI7RfDCqWDnE/NUhbNDU5k292VAfPGdz65Fc9Kj24XwQnace4vORbLDBe7o6PhA8Zd0pya/Q89qH8UHrFzpAPB7FFfLSOyr6uT14yEqDdjxED20bygd17+gBcycwwSxv6EV8NfCMbZddsKEHtw3hg7CzekBMDuUJeOb1/DHOAp4wZPhP2ejpbUP5wPKTLvBuIxaY6t04T3QHT9h88UU7loW2YXwAS5x6wJyuLGH5Xkzxriagf0v0lsdYZtqGKwBD/tEDFvblgF+8lveJtUD3lYbvzcUy1T5GAWiZqQcsiubo7aXkrqwCeq82JaUYy1zHRAWg6nk9YF4LBss7b+RtfEXQeZT1ggPLZOd0BcB/i6YDfBRGBwe9jzdLQ0Hf9eZf1bDM1uYqADA2Xwe4h2Gmt5EbHwq6rrvghoZlurZCBWhxXwdaX7qW3sU/a8JAz7WsVzUs+zepAKH71cN7fmTmAi/Ctr0G6LjKtPNONIY/mBUAmF2kHE4kg5teg7a/Ieh5iw2N428WFaD1PeXS6XZ7C1e6gK43o6FMragCVNylKYbdyVZ6B1mjQN+fOY0FXotQASAmR7GfyaZ6AwUJwaDvCg/QaN6rqwTUSlUr159qsPHTDtYBvW9G4/m8pRIAM/9RCTtSdTN893uB7rs6DQi+i1YDGlxQaRJVO4NXGB8Aug95hIbUNkENMM1+r85iqpbG7kxD8IDfo0HVEtQAqHNCGStVayOXMxE8YW/NqCD+EqAGQMxTRfpRdTRwB2uAJ6zyDA3sv8MVgZANxSoUh1H1MGxvRoBnTEZD+3cTRQAaHtb4fgPqGKN2rAZ4xlFocN/1UQWg62UurQPZl8YsbxJ4yKhco4OO+coA9L/J8xOQbzJkl+qDhzSdQQO8O0gZgN5nNLpTwXRHDJgjwQ885Tw0xLfqqAPQ8vv3NC+tfkD/yHg9/Rw8ZqsiY4RveioEEDL+pM0de+qYQGAM1wxXSgR4zKAMNMqOZSp9OGTbn7ZSnu6dAMwD0WA7loIH3Y4GOqWKWgAQ2LT36Akxn1cH/i0G63U0qDzw1wo8AzQjhU86q6bwE2N1qw4o3Ot6bkNgrfkajbVtoYf6BA313mBQt/M5dPYHVtMZNNy/V/dIPxkp5zJQt9FBDXEF8C5FA57d1wOFFhmogmGgbMQ2GyIeBt5P7EYMte3BHmcrGufXnUBVy/xcRMT0EJ7KT9Cg3+voYZrYjNOjhqDqgAf44duPgPcIGnb7mgBPYrqAhvl2DVC0YQqWaOsBvFY08ukdPMgCNMxXK4OaQSuLsOSZwNuh2NChY1Owp/jMZpguhYKaPR9iqduAt3ImGv1HvTxD3Ww0ypdCQMmI3RqWmurHdByNv7Yv0gNUv49G+UYlUHLUayw9vRLwLkav8N0cf71VT0ejnBEOKlY7jC6+qAO83R3eAeKd3vqqew+N8tMoUHHYa3TxfVvgrZmN3mNKUx11folGOa8FKFjpFw1dtPcBXssl9CYdSVF6mV6ERtnRDxTs8hhd1SYD81b0Mgu/rq6HiINonBcDv2mJHV1eDszjNW8DMT+xlnIjstE4HwH+qqno+g5gblOA3mhRUhOlmp1CA/04jK/zU3Q92cQUkYleqnayn0mV+jsdaKDtXYB9ejG6nmIBXv9z6MVmxtdRoe1uOxrqVcBt+Q7dvBAMzFvRu3X+e1ZNnqozrqPBvm3hCj+Pbl6vBMxTNC8HEbU/NvaLoKnQbfl/HGi0HR2AueFDdDOtMjB/Vozesfbk6PrJvVrUrPBBQESjrmPi96Tb0YjvAOZOr9HN9KrAXO81etuarciBRj4nnKlPPrqZXhWYQ9NRWq3AO9KGbt6OAGZzCkrrkwCeEQ5082YV4P4GxXUKsE5yopuXwoD7SxTXpxaWCU50M7UicA9wyMt84BziQDd/CwDu9vkorvlhHF2L0M3tJuCu/xLl9SdgbJSDrjsXAXvEfRTYbgxh99D1wuHAXuEqCuwzE8MBdP1FJ2D3O4ESux3oJ6Hr16KA/1cU2b50NXJd2xkI/N+gyNpD6Hahq/mxoGACyuxVIP/Y4UpGM1DQqgnNVrrtWLpzSxAoOEVDoZ1GFpRb2sMvQMWxTpTaHmQDsOSiNUGg4nA7im0Dsm0laAcagJIxdpTbELK/ENF5pD2oOcKOcmsH6jAnvtz0MSg62o6Cm0tWaX03M6ga60DJfU2m8mwniu5b/cVrKLv/6O5rlF7NT1+WvSi/1XUVdgYFuLWeaqejBA/VUeeXKMLx+oktQhk+qBfLdg2F+IVOal9BOW6iiwFvUJAX6iBoq4aSnKZe2wwU5k8Us6y0oTSfUOvTDJRnra9C1XZpKNHPa6himZuLQn0tRAnT6Eco1xfD+Ewxf6Fo32vGFBibgdJduMjCUHdNNkr4gzF+NJXGn3KilGclNHar3rTjRSjrD76L7Vj1A7+ortbdmSj0jtw3eRqW+7/c/+X+L/d/uf/L/V/u/3L/l/v//0P/X+L/r3L/l/u/HIAA" />
+    <link
+      rel="shortcut icon"
+      href="data:image/x-icon;base64,UklGRtASAABXRUJQVlA4TMMSAAAv/8F/EH+HoG3blD/pSG32UxAQFPk/moCg4P/oBAJJavtDbbRtG40NOT0jwgYBAkDAAQFAArDLICAARjA1HRADCqxhf04whCEM6ImQMVZQZtiCTlFLXHTwzajPNiRT6yOoEadHVvdlHLEhZO3/Bn1WkWhFmstFBanIWjp4GADaldJs2641A0NREAULii0ae+8pGsXexd6wlzD2hmLXSGJNQdMsxF4wWC+97JpgwBpFbFhADG3KWfePEGbW2mc4M+tuRPR/ArDc/+X+L/d/uf/L/V/u/3L//2+/trtnjx49e7dY4mzXv587vJ0FSvRvFfe7TdSyt/euAG5XW/xUyrST/fyA1jIpU8K0Y62BMcD6Vrz+6gbMlbcUilZxvD8o2Oa5XN1rA4quKRaqw6GgbPO/RGqTCRQO2i1P2jJQfIM4JYDyicKUBDo8LkpXLXqo8lKQ8uqDLscKUhzoNF2MMvz0EitGg0GvFQuE6Dbo95gQjdeRVYZeBejoMxlKBB2Hy1BLPcF7CcoAXf8tQau4Qhv5s6RJUAeOlhvPvdDw6TiOqwKUDfQRJzQs+UIzuisCtIfhBrr4hu6mAE2mi0dXM+gyBKgRWeX3Lp2jeyY/b4B8Drr8G12B/KTQ3XRtO1lFlN+VZJGaawlk9QVoGNlodH0m2acC9DHZNjeGksXIT5GZ7Kobn5LNk58MoDblu9GQbIv8HCZrgG6Gkh2Vn0Syfm7kA/lf8vMlmdWNh3Tv5Wcw2TY3LpBFoPy2JzvpRjJZWwGqRXbXjUSyYfKj+ZMVuLGAbL785AB1OLo5mmyr/Nwna+5ON7Jj8nOFLNqdhmRp8nOSbJQbWiBZjvwkk81yIxuoAzT52Um2zI0bZI1QfreQrXfjAFkPAdpIttWNr8hiBWgVWZIbM8hWCFA82S9u9Cb7UYCWkO1zoyHZeQFaRJbsmt1CliVAC9V4CNQBTgFaTLbXtRNkjVCAl5L97FoiWV8JSiD7wbVpZFYJWku2xbUvyLZL0Ddk61yrQXZagn4gW+rSWyB/JkF7yWa6dIEsRJOgE2QjXfqOrD1K8EWyni7FkY0ToQyyVi71IFsrQtlkNVzRIsiOipDDTGW2u/AcyP8WIaxGBVkunCQLdspQK7L/uLCBrD3KcB+y3S6MIYsVoilkq1xoSva1EK0mm1BavpnsrBDtJutS2mUgzxGiy2ThpW0ni0IhfkUGr0qZRDZAirQwsrOltCFbLkXYgWxLSYUWskNiNI5sSklXgPyJGK0j61jSZrIITYyOkgU7ShhL1gvF+DEZpJfQiGyJHGmhZD9+kAvkh+QIPyWb9UEq3VNBmk3W/oMEskgU5J1klkJE7E02SJLSyOASojOMbI0k2YPINiJmAPkpScIuZIMQk8hM70QpjixCw1iyZijKe8ggAxuTTZKlx3Q7soH8B1nSapANP0CXIUs4hKz6l2SVncK0iQyCyPqgMF+no18lTfYQ5c5LE/ZSLaBQnNaq1gXF+bJqi+XJHqpYijxhP7XM7wQqUa22KNDpas2TKK2mUsclCieoZM4VqX0qtUeRfmNWaJFMYSeFUoUqQR1LvlDdVKcbCrUWqcwqqcIpylwVq+OqhDnEqrCiIsNQrmMU+V6w9iqSKVh5gUo0QskepEScaO1W4qRovQ9WIKhAtHC4Ar1Rto8qsFW4isP5HgsXzmJrgtJ9g22+eGnNuC6IFyYyhTvk63UAzzgU8OE8+yXsLEvgewnTmnD0QxHfzPGDjL3j+EXGsAJDZ03G6jBAioi9MHO00yRsC7AelLAuPB/b5SsTmJPkaz1XrXzp0ppywWrpugXsodnCZeWDqbJlq6qAOU20joGK3TXJilEC9gtWTqAadfLlagcoGi9X7VQJfChVf4KyfTShmq0OHJSpgjCFovJE6mdQ2SpSnyllviFQGaB2a7s8xSkGG8UpP0y14IfSlATKf6EJUzv14DtZugo6DM0SpbF6gF6aIL0K0AX8IEirgb4/S2imGNlq0YXl9+KA7k4p2gf0cfgwiAM2S1FnhjuIa1iC78rQVaDvhoi2ZhzQ3iZCIxiSEREvmThguQRl+dFF2j7AWSx+lwVoIdCvwBLzojigfp745IXR+T8vCVNYYLz4fA30w7H08SywT3jsdRguuZATyRKWKTv7gL695gIeYYEudsnR2jD8ii6PYYFlknMK6COLXcuJZDGdFpxeDKvQzRMsUCNbbG4BfdBrdzCWBXo6pSaGYQq6/a4uC6wRmnsmhgz38LyJxe+8zMQCfT+knMcCkS8lJsvCcI6kqDkLdHcIzGygb6uR4O1AFlgmLy+DGPYicSIPpIjLAqCvZ6dyRvNUfiwsrysybEPy5xEs0KZQVpYCfUQ+HR7jgVhNUnJCGVYi52we+FZS4oE+JIelsAWP5ZKc5FRimI+8dyqwQORzMYkH+sDnTLiLB7oUC0lOJYYZyK2N5oEpQrIE6P0z2fB9Ix7YLiKvKzJMQAXTgnj8z0nIfKA331UBk3gg/JF8PA9mGIVKauN4oHmeeMwCelOGGvhPUx4Y6BSOTAtDDKp6N4QHFgtHLDCmKYPJTPCLaNwxMwxFha1MARclYxgwpqlk+4wHqj6Si+vAOBSVfhHJA01yxSKawXRbLbzozwPRNqE4BYzDUfVtTDBFEwmtHYP5jnLaRCbYIBLJwDgW1S/swAS/CURxAwa/BzrApzWYgi7JwxZgnIy6/E8AD0Q8kIbcCIaALH1gEhM0eC0MS4AxDvUaxwSd8kUhK4ihYrZu7NFMMMghCWOBMR71m/MxE8zQ5OAmMIa/0xHeC2OCVW8f/XH+RPLObRtXLVswZ/bMGR/Ots5fmrBha9K+4+f+eJTr9I1pn3NsQl2n+jEpaQ5v3DVm9tqfTt0r8GUdBMaoQn3hdv25XLXdsAXfnc5y+qCKPuLYhXqP8ySlBrccviI5w+ZT+goYmzr0lXs5yeqBSra0HLvpTK6P6FUljqOo1/dXkqzRtcDzNxix6WKh72cqMHbVdOC8l7xsYH0oSy0drAdf+3TSzBxXUe28i9umdAqEsrnZrIO5vhqtKzAOR3WzU1YPawBlvLlj/BWnLyYZGAMeqZF9ImFgFBjFarFHC30t+bU55iL7+7Prh0SB0QwZebjIp7IcGCvnsGh3kiY3N4NBrTz1suYzeRzEkYjk+WdX960CBrdJYo6PZAgwNiymeXtkbkd/MMTBkzN8IanAeRjdf7V/VnMw1H0u+DyKG3F009zIPRzXHAx41/M+jnXAaPoDXSw8taidGYx67zRfRlZFjklYsnb7q+ggMPSmSa98F8OAMfTlB2/3TYgEL7DyZqeP4nfgXI/arVVdzOAtfnrfJ1HYkKPG3thI8CqDt2s+iATwrgfm+BzuB3pZUO8PH4MWDV53cLJvYQ8Y2UW7dmxKWDRj7IDPm0V6EoDVmg8hp7qhiUhDF7Xcu+d2b7QObV/VE8A0h+9gKpTFwc0GWTcfT8/D66FcEP6nC67mZxxNnN6jlr4gxuYruAhlq1+DfvO+P5PlxNLPBXFBlVsUpb67snNOdFXdwMBi30BxkzLD0jRmRXJ6Mbp/3J8LKl+nK1F7dmx536q6gEE2n8BKKAvrDVyanGFD8n0mLgi7xFOi9vfumS1NysFopw/gboCHC+k8dcelPOROYoOQ83wl5hyb18akFli9P+fn4Lmj+sUfeOhENRPZIDhVjQ/f7p8cpRJs9vZs/cEz1x265uQrVHoVGwQcVgYRtT8TWqtjTvXq0qzggWsOWpP6FtXXFrOB368KffhwVWNFoEqm1/Z2SxvwtMGfLTiQhXrV4tjAtE0tRO3yxCAloKPNK3OeHhkInjVqxDc3bKhrbSobwEpNLUR8s6a6CrDEC3ux5iPwqM2m73mCHtA5gQ/inKohFm6JVMB8xcty/j7EHzynqY318Bv0lI7RfDCqWDnE/NUhbNDU5k292VAfPGdz65Fc9Kj24XwQnace4vORbLDBe7o6PhA8Zd0pya/Q89qH8UHrFzpAPB7FFfLSOyr6uT14yEqDdjxED20bygd17+gBcycwwSxv6EV8NfCMbZddsKEHtw3hg7CzekBMDuUJeOb1/DHOAp4wZPhP2ejpbUP5wPKTLvBuIxaY6t04T3QHT9h88UU7loW2YXwAS5x6wJyuLGH5Xkzxriagf0v0lsdYZtqGKwBD/tEDFvblgF+8lveJtUD3lYbvzcUy1T5GAWiZqQcsiubo7aXkrqwCeq82JaUYy1zHRAWg6nk9YF4LBss7b+RtfEXQeZT1ggPLZOd0BcB/i6YDfBRGBwe9jzdLQ0Hf9eZf1bDM1uYqADA2Xwe4h2Gmt5EbHwq6rrvghoZlurZCBWhxXwdaX7qW3sU/a8JAz7WsVzUs+zepAKH71cN7fmTmAi/Ctr0G6LjKtPNONIY/mBUAmF2kHE4kg5teg7a/Ieh5iw2N428WFaD1PeXS6XZ7C1e6gK43o6FMragCVNylKYbdyVZ6B1mjQN+fOY0FXotQASAmR7GfyaZ6AwUJwaDvCg/QaN6rqwTUSlUr159qsPHTDtYBvW9G4/m8pRIAM/9RCTtSdTN893uB7rs6DQi+i1YDGlxQaRJVO4NXGB8Aug95hIbUNkENMM1+r85iqpbG7kxD8IDfo0HVEtQAqHNCGStVayOXMxE8YW/NqCD+EqAGQMxTRfpRdTRwB2uAJ6zyDA3sv8MVgZANxSoUh1H1MGxvRoBnTEZD+3cTRQAaHtb4fgPqGKN2rAZ4xlFocN/1UQWg62UurQPZl8YsbxJ4yKhco4OO+coA9L/J8xOQbzJkl+qDhzSdQQO8O0gZgN5nNLpTwXRHDJgjwQ885Tw0xLfqqAPQ8vv3NC+tfkD/yHg9/Rw8ZqsiY4RveioEEDL+pM0de+qYQGAM1wxXSgR4zKAMNMqOZSp9OGTbn7ZSnu6dAMwD0WA7loIH3Y4GOqWKWgAQ2LT36Akxn1cH/i0G63U0qDzw1wo8AzQjhU86q6bwE2N1qw4o3Ot6bkNgrfkajbVtoYf6BA313mBQt/M5dPYHVtMZNNy/V/dIPxkp5zJQt9FBDXEF8C5FA57d1wOFFhmogmGgbMQ2GyIeBt5P7EYMte3BHmcrGufXnUBVy/xcRMT0EJ7KT9Cg3+voYZrYjNOjhqDqgAf44duPgPcIGnb7mgBPYrqAhvl2DVC0YQqWaOsBvFY08ukdPMgCNMxXK4OaQSuLsOSZwNuh2NChY1Owp/jMZpguhYKaPR9iqduAt3ImGv1HvTxD3Ww0ypdCQMmI3RqWmurHdByNv7Yv0gNUv49G+UYlUHLUayw9vRLwLkav8N0cf71VT0ejnBEOKlY7jC6+qAO83R3eAeKd3vqqew+N8tMoUHHYa3TxfVvgrZmN3mNKUx11folGOa8FKFjpFw1dtPcBXssl9CYdSVF6mV6ERtnRDxTs8hhd1SYD81b0Mgu/rq6HiINonBcDv2mJHV1eDszjNW8DMT+xlnIjstE4HwH+qqno+g5gblOA3mhRUhOlmp1CA/04jK/zU3Q92cQUkYleqnayn0mV+jsdaKDtXYB9ejG6nmIBXv9z6MVmxtdRoe1uOxrqVcBt+Q7dvBAMzFvRu3X+e1ZNnqozrqPBvm3hCj+Pbl6vBMxTNC8HEbU/NvaLoKnQbfl/HGi0HR2AueFDdDOtMjB/Vozesfbk6PrJvVrUrPBBQESjrmPi96Tb0YjvAOZOr9HN9KrAXO81etuarciBRj4nnKlPPrqZXhWYQ9NRWq3AO9KGbt6OAGZzCkrrkwCeEQ5082YV4P4GxXUKsE5yopuXwoD7SxTXpxaWCU50M7UicA9wyMt84BziQDd/CwDu9vkorvlhHF2L0M3tJuCu/xLl9SdgbJSDrjsXAXvEfRTYbgxh99D1wuHAXuEqCuwzE8MBdP1FJ2D3O4ESux3oJ6Hr16KA/1cU2b50NXJd2xkI/N+gyNpD6Hahq/mxoGACyuxVIP/Y4UpGM1DQqgnNVrrtWLpzSxAoOEVDoZ1GFpRb2sMvQMWxTpTaHmQDsOSiNUGg4nA7im0Dsm0laAcagJIxdpTbELK/ENF5pD2oOcKOcmsH6jAnvtz0MSg62o6Cm0tWaX03M6ga60DJfU2m8mwniu5b/cVrKLv/6O5rlF7NT1+WvSi/1XUVdgYFuLWeaqejBA/VUeeXKMLx+oktQhk+qBfLdg2F+IVOal9BOW6iiwFvUJAX6iBoq4aSnKZe2wwU5k8Us6y0oTSfUOvTDJRnra9C1XZpKNHPa6himZuLQn0tRAnT6Eco1xfD+Ewxf6Fo32vGFBibgdJduMjCUHdNNkr4gzF+NJXGn3KilGclNHar3rTjRSjrD76L7Vj1A7+ortbdmSj0jtw3eRqW+7/c/+X+L/d/uf/L/V/u/3L/l/v//0P/X+L/r3L/l/u/HIAA"
+    >
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css">
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bulma@1.0.2/css/bulma.min.css"
+    >
 
     <script src="pdfium.js?v={pdfium-branch}"></script>
 
     <script>
-        // variables
-        let currentPageIndex = 1;
-        let pageLoaded = false;
-        let moduleLoaded = false;
-        let debugMode = false;
-        let autoOpenMode = true;
-        let doc;
-        let FPDF = {};
-        let Module = null;
+    "use strict";
+    // variables
+    let currentPageIndex = 1;
+    let pageLoaded = false;
+    let moduleLoaded = false;
+    let debugMode = false;
+    let autoOpenMode = true;
+    let doc;
+    const FPDF = {};
+    let Module = null;
 
-        // pdfium initialization
-        Object.assign(FPDF, {
-            ANNOT: 0x01, // Set if annotations are to be rendered.
-            LCD_TEXT: 0x02, // Set if using text rendering optimized for LCD display.
-            NO_NATIVETEXT: 0x04, // Don't use the native text output available on some platforms
-            GRAYSCALE: 0x08, // Grayscale output.
-            DEBUG_INFO: 0x80, // Set if you want to get some debug info. Please discuss with Foxit first if you need to collect debug info.
-            NO_CATCH: 0x100, // Set if you don't want to catch exception.
-            RENDER_LIMITEDIMAGECACHE: 0x200, // Limit image cache size.
-            RENDER_FORCEHALFTONE: 0x400, // Always use halftone for image stretching.
-            PRINTING: 0x800, // Render for printing.
-            REVERSE_BYTE_ORDER: 0x10, // Set whether render in a reverse Byte order, this flag only.
-            Bitmap_Gray: 1,
-            Bitmap_BGR: 2,
-            Bitmap_BGRx: 3,
-            Bitmap_BGRA: 4,
-            LAST_ERROR: { // Last error types
-                SUCCESS: 0,
-                UNKNOWN: 1,
-                FILE: 2,
-                FORMAT: 3,
-                PASSWORD: 4,
-                SECURITY: 5,
-                PAGE: 6
-            }
-        });
+    // pdfium initialization
+    Object.assign(FPDF, {
+      ANNOT: 0x01, // Set if annotations are to be rendered.
+      LCD_TEXT: 0x02, // Set if using text rendering optimized for LCD display.
+      NO_NATIVETEXT: 0x04, // Don't use the native text output available on some platforms
+      GRAYSCALE: 0x08, // Grayscale output.
+      DEBUG_INFO: 0x80, // Set if you want to get some debug info. Please discuss with Foxit first if you need to collect debug info.
+      NO_CATCH: 0x1_00, // Set if you don't want to catch exception.
+      RENDER_LIMITEDIMAGECACHE: 0x2_00, // Limit image cache size.
+      RENDER_FORCEHALFTONE: 0x4_00, // Always use halftone for image stretching.
+      PRINTING: 0x8_00, // Render for printing.
+      REVERSE_BYTE_ORDER: 0x10, // Set whether render in a reverse Byte order, this flag only.
+      Bitmap_Gray: 1,
+      Bitmap_BGR: 2,
+      Bitmap_BGRx: 3,
+      Bitmap_BGRA: 4,
+      LAST_ERROR: {
+        // Last error types
+        SUCCESS: 0,
+        UNKNOWN: 1,
+        FILE: 2,
+        FORMAT: 3,
+        PASSWORD: 4,
+        SECURITY: 5,
+        PAGE: 6,
+      },
+    });
 
-        const I8 = Int8Array;
-        const I16 = Int16Array;
-        const I32 = Int32Array;
-        const U8 = Uint8Array;
-        const CH = U8;
-        const U16 = Uint16Array;
-        const U32 = Uint32Array;
-        const F32 = Float32Array;
-        const F64 = Float64Array;
+    const I8 = Int8Array;
+    const I16 = Int16Array;
+    const I32 = Int32Array;
+    const U8 = Uint8Array;
+    const CH = U8;
+    const U16 = Uint16Array;
+    const U32 = Uint32Array;
+    const F32 = Float32Array;
+    const F64 = Float64Array;
 
-        const H = (t, s, d) => f => {
-            const [m, ...a] = heap(t, s);
-            const v = f(...a.map(x => x.p));
+    const H = (t, s, d) => (f) => {
+      const [m, ...a] = heap(t, s);
+      const v = f(...a.map((x) => x.p));
 
-            if (!v) {
-                m.free();
-                return d;
-            }
+      if (!v) {
+        m.free();
+        return d;
+      }
 
-            const r = a.map(x => x.v);
-            m.free();
-            return r;
+      const r = a.map((x) => x.v);
+      m.free();
+      return r;
+    };
+
+    const F = FPDF.Bitmap_BGRA;
+    const C = 4;
+
+    // classes
+    class Page {
+      constructor(index, processor) {
+        this.index = index;
+        this.src = null;
+        this.processor = processor;
+      }
+
+      render() {
+        const canvas = document.createElement("canvas");
+        this.processor.render(this.index, canvas, 3.0, 90);
+
+        const dataUri = canvas.toDataURL();
+        this.updateImage(dataUri);
+      }
+
+      createImage() {
+        const image = document.createElement("img");
+        const pageIndex = this.index;
+
+        image.id = "pageImage" + (pageIndex + 1);
+        image.src = "";
+        image.className = "is-hidden page-list-item";
+
+        return image;
+      }
+
+      updateImage(dataUri) {
+        this.src = dataUri;
+
+        // update image in pageList
+        const pageIndex = this.index;
+        const image = document.getElementById("pageImage" + (pageIndex + 1));
+        image.src = dataUri;
+        image.classList.remove("is-hidden");
+        image.onclick = () => {
+          openModal();
+          changeCurrentPageItem(pageIndex + 1);
         };
 
-        const F = FPDF.Bitmap_BGRA;
-        const C = 4;
+        const container = image.closest(".cell");
+        const loaderWrapper = container.querySelector(".page-loader-wrapper");
 
-        // classes
-        class Page {
-            constructor(index, processor) {
-                this.index = index;
-                this.src = null;
-                this.processor = processor;
-            }
+        if (loaderWrapper) {
+          loaderWrapper.remove();
+        }
+      }
 
-            render() {
-                let canvas = document.createElement('canvas');
-                this.processor.render(this.index, canvas, 3.0, 90);
+      get loaded() {
+        return this.src !== null;
+      }
+    }
 
-                let dataUri = canvas.toDataURL();
-                this.updateImage(dataUri);
-            }
+    class Processor {
+      constructor(wasmData) {
+        this.wasmData = wasmData;
+      }
 
-            createImage() {
-                let image = document.createElement('img');
-                let pageIndex = this.index;
+      getPageSize(i = 0, s = 2) {
+        return H(
+          F64,
+          2,
+          [-1, -1]
+        )((w, h) => FPDF.GetPageSizeByIndex(this.wasmData.wasm, i, w, h)).map(
+          (v) => Number.parseInt(v) * s
+        );
+      }
 
-                image.id = "pageImage" + (pageIndex + 1);
-                image.src = '';
-                image.className = "is-hidden page-list-item";
+      getRender(i = 0, w, h) {
+        const flag = FPDF.REVERSE_BYTE_ORDER | FPDF.ANNOT;
+        const heap = Module.wasmExports.malloc(w * h * C);
 
-                return image;
-            }
-
-            updateImage(dataUri) {
-                this.src = dataUri;
-
-                // update image in pageList
-                let pageIndex = this.index;
-                let image = document.getElementById("pageImage" + (pageIndex + 1));
-                image.src = dataUri;
-                image.classList.remove("is-hidden");
-                image.onclick = function () {
-                    openModal();
-                    changeCurrentPageItem(pageIndex + 1);
-                };
-
-                const container = image.closest('.cell');
-                const loaderWrapper = container.querySelector('.page-loader-wrapper');
-
-                if (loaderWrapper) {
-                    loaderWrapper.remove();
-                }
-            }
-
-            get loaded() {
-                return this.src !== null;
-            }
+        for (let i = 0; i < w * h * C; i++) {
+          Module.HEAPU8[heap + i] = 0;
         }
 
-        class Processor {
-            constructor(wasmData) {
-                this.wasmData = wasmData;
-            }
+        const bmap = FPDF.Bitmap_CreateEx(w, h, F, heap, w * C);
+        const page = FPDF.LoadPage(this.wasmData.wasm, i);
 
-            getPageSize(i = 0, s = 2) {
-                return H(F64, 2, [-1, -1])((w, h) => FPDF.GetPageSizeByIndex(this.wasmData.wasm, i, w, h)).map(v => parseInt(v) * s);
-            }
+        FPDF.Bitmap_FillRect(bmap, 0, 0, w, h, 0xff_ff_ff_ff);
+        FPDF.RenderPageBitmap(bmap, page, 0, 0, w, h, 0, flag);
+        FPDF.Bitmap_Destroy(bmap);
+        FPDF.ClosePage(page);
 
-            getRender(i = 0, w, h) {
-                const flag = FPDF.REVERSE_BYTE_ORDER | FPDF.ANNOT;
-                const heap = Module.wasmExports.malloc(w * h * C);
+        return heap;
+      }
 
-                for (let i = 0; i < w * h * C; i++) {
-                    Module.HEAPU8[heap + i] = 0;
-                }
+      getPageRender(n = 0, w, h) {
+        const pageRenderPtr = this.getRender(n, w, h);
+        const pageRenderData = [];
 
-                const bmap = FPDF.Bitmap_CreateEx(w, h, F, heap, w * C);
-                const page = FPDF.LoadPage(this.wasmData.wasm, i);
-
-                FPDF.Bitmap_FillRect(bmap, 0, 0, w, h, 0xFFFFFFFF);
-                FPDF.RenderPageBitmap(bmap, page, 0, 0, w, h, 0, flag);
-                FPDF.Bitmap_Destroy(bmap);
-                FPDF.ClosePage(page);
-
-                return heap;
-            }
-
-            getPageRender(n = 0, w, h) {
-                let pageRenderPtr = this.getRender(n, w, h);
-                let pageRenderData = [];
-
-                for (let v = 0; v < w * h * C; v++) {
-                    pageRenderData.push(Module.HEAPU8[pageRenderPtr + v]);
-                }
-
-                Module.wasmExports.free(pageRenderPtr);
-
-                return pageRenderData;
-            }
-
-            render(n = 0, canvas, scale, rotation) {
-                let [w, h] = this.getPageSize(n, scale, rotation);
-                w = Math.ceil(w);
-                h = Math.ceil(h);
-
-                const data = this.getPageRender(n, w, h, rotation);
-
-                canvas.width = w;
-                canvas.height = h;
-
-                const x = canvas.getContext('2d');
-                const i = x.createImageData(w, h);
-                i.data.set(data);
-                x.putImageData(i, 0, 0);
-            }
-
-            getLastError() {
-                let lastError = FPDF.GetLastError();
-
-                switch (lastError) {
-                    case FPDF.LAST_ERROR.SUCCESS:
-                        return "success";
-                        break;
-                    case FPDF.LAST_ERROR.UNKNOWN:
-                        return "unknown error";
-                        break;
-                    case FPDF.LAST_ERROR.FILE:
-                        return "file not found or could not be opened";
-                        break;
-                    case FPDF.LAST_ERROR.FORMAT:
-                        return "file not in PDF format or corrupted";
-                        break;
-                    case FPDF.LAST_ERROR.PASSWORD:
-                        return "password required or incorrect password";
-                        break;
-                    case FPDF.LAST_ERROR.SECURITY:
-                        return "unsupported security scheme";
-                        break;
-                    case FPDF.LAST_ERROR.PAGE:
-                        return "page not found or content error";
-                        break;
-                    default:
-                        return "unknown error";
-                }
-            }
+        for (let v = 0; v < w * h * C; v++) {
+          pageRenderData.push(Module.HEAPU8[pageRenderPtr + v]);
         }
 
-        class Doc {
-            constructor(wasmData) {
-                this.processor = new Processor(wasmData);
-            }
+        Module.wasmExports.free(pageRenderPtr);
 
-            setPages(pagesCount) {
-                this.pages = Array(pagesCount).fill(null);
-            }
+        return pageRenderData;
+      }
 
-            createAllPages() {
-                for (let i = 0; i < this.pages.length; i++) {
-                    this.pages[i] = new Page(i, this.processor);
-                }
-            }
+      render(n = 0, canvas, scale, rotation) {
+        let [w, h] = this.getPageSize(n, scale, rotation);
+        w = Math.ceil(w);
+        h = Math.ceil(h);
 
-            getPage(index) {
-                let page = this.pages[index];
+        const data = this.getPageRender(n, w, h, rotation);
 
-                if (!page) {
-                    page = new Page(index);
-                    this.pages[index] = page;
-                }
+        canvas.width = w;
+        canvas.height = h;
 
-                return page;
-            }
+        const x = canvas.getContext("2d");
+        const i = x.createImageData(w, h);
+        i.data.set(data);
+        x.putImageData(i, 0, 0);
+      }
 
-            async renderPages() {
-                const wasmBuffer = this.processor.wasmData.wasmBuffer;
-                const wasm = this.processor.wasmData.wasm;
+      getLastError() {
+        const lastError = FPDF.GetLastError();
 
-                const renderNextPage = async (index) => {
-                    if (index < doc.pages.length) {
-                        let page = doc.getPage(index);
-                        if (!page.loaded) {
-                            await new Promise(requestAnimationFrame);
-                            page.render();
-                        }
-                        setTimeout(() => renderNextPage(index + 1), 100);
-                    } else {
-                        Module.wasmExports.free(wasmBuffer);
-                        FPDF.CloseDocument(wasm);
-                        FPDF.DestroyLibrary();
-                    }
-                }
+        switch (lastError) {
+          case FPDF.LAST_ERROR.SUCCESS:
+            return "success";
+            break;
+          case FPDF.LAST_ERROR.UNKNOWN:
+            return "unknown error";
+            break;
+          case FPDF.LAST_ERROR.FILE:
+            return "file not found or could not be opened";
+            break;
+          case FPDF.LAST_ERROR.FORMAT:
+            return "file not in PDF format or corrupted";
+            break;
+          case FPDF.LAST_ERROR.PASSWORD:
+            return "password required or incorrect password";
+            break;
+          case FPDF.LAST_ERROR.SECURITY:
+            return "unsupported security scheme";
+            break;
+          case FPDF.LAST_ERROR.PAGE:
+            return "page not found or content error";
+            break;
+          default:
+            return "unknown error";
+        }
+      }
+    }
 
-                await renderNextPage(0);
-            }
+    class Doc {
+      constructor(wasmData) {
+        this.processor = new Processor(wasmData);
+      }
+
+      setPages(pagesCount) {
+        this.pages = Array(pagesCount).fill(null);
+      }
+
+      createAllPages() {
+        for (let i = 0; i < this.pages.length; i++) {
+          this.pages[i] = new Page(i, this.processor);
+        }
+      }
+
+      getPage(index) {
+        let page = this.pages[index];
+
+        if (!page) {
+          page = new Page(index);
+          this.pages[index] = page;
         }
 
-        // runtime initialized
-        PDFiumModule().then(function (pdfiumModule) {
-            Module = pdfiumModule;
+        return page;
+      }
 
-            moduleLoaded = true;
+      async renderPages() {
+        const wasmBuffer = this.processor.wasmData.wasmBuffer;
+        const wasm = this.processor.wasmData.wasm;
 
-            if (pageLoaded) {
-                console.log('The module was loaded!');
+        const renderNextPage = async (index) => {
+          if (index < doc.pages.length) {
+            const page = doc.getPage(index);
+            if (!page.loaded) {
+              await new Promise(requestAnimationFrame);
+              page.render();
             }
+            setTimeout(() => renderNextPage(index + 1), 100);
+          } else {
+            Module.wasmExports.free(wasmBuffer);
+            FPDF.CloseDocument(wasm);
+            FPDF.DestroyLibrary();
+          }
+        };
 
-            checkIfEverythingWasLoaded();
+        await renderNextPage(0);
+      }
+    }
+
+    // runtime initialized
+    PDFiumModule().then((pdfiumModule) => {
+      Module = pdfiumModule;
+
+      moduleLoaded = true;
+
+      if (pageLoaded) {
+        console.log("The module was loaded!");
+      }
+
+      checkIfEverythingWasLoaded();
+    });
+
+    // functions
+    async function loadFile() {
+      try {
+        changeButton("Loading file from input...", "warning");
+
+        resetOnLoad();
+
+        const files = fileInput.files;
+
+        if (files.length <= 0) {
+          throw { message: "Select a PDF file or type a public PDF url" };
+        }
+
+        const file = files[0];
+
+        const fileByteArray = await fileToByteArray(file);
+
+        if (fileByteArray.length <= 0) {
+          throw { message: "The PDF file is invalid" };
+        }
+
+        changeButton("Processing file...", "warning");
+
+        setTimeout(() => {
+          processPDF(fileByteArray);
+        }, 300);
+      } catch (error) {
+        changeButton("Error while load file", "danger");
+        console.log("Error while load file: " + error.message);
+      }
+    }
+
+    async function loadFileFromURL(url) {
+      try {
+        changeButton("Loading file from URL...", "warning");
+
+        resetOnLoad();
+
+        const response = await fetch(url);
+        const fileBuffer = await response.arrayBuffer();
+        const fileByteArray = new Uint8Array(fileBuffer);
+
+        if (fileByteArray.length <= 0) {
+          throw { message: "The PDF file is invalid" };
+        }
+
+        changeButton("Processing file...", "warning");
+
+        setTimeout(() => {
+          processPDF(fileByteArray);
+        }, 300);
+      } catch (error) {
+        changeButton("Error while load file from URL", "danger");
+        console.log("Error while load file from URL: " + error.message);
+      }
+    }
+
+    async function processPDF(fileByteArray) {
+      try {
+        // html general
+        changeButton("Processing file...", "warning");
+
+        const pageListContainer = document.getElementById("pageListContainer");
+        const pageList = document.getElementById("pageList");
+        const pageListTitle = document.getElementById("pageListTitle");
+
+        pageListContainer.style.display = "none";
+        pageList.innerHTML = "";
+
+        // check file size
+        console.log("Getting file size...");
+
+        const fileSize = fileByteArray.length;
+        console.log("File size: " + fileSize + " bytes");
+
+        // init library
+        console.log("Initializing library...");
+
+        FPDF.Init();
+
+        // load document to memory
+        console.log("Loading data to buffer...");
+
+        const wasmBuffer = Module.wasmExports.malloc(fileSize);
+        Module.HEAPU8.set(fileByteArray, wasmBuffer);
+
+        // create document
+        console.log("Loading document...");
+
+        doc = new Doc({
+          wasm: FPDF.LoadMemDocument(wasmBuffer, fileSize, ""),
+          wasmBuffer,
         });
 
-        // functions
-        async function loadFile() {
-            try {
-                changeButton('Loading file from input...', 'warning');
+        // check last error
+        const lastError = doc.processor.getLastError();
+        console.log("Load document state: " + lastError);
 
-                resetOnLoad();
+        // count page
+        console.log("Couting pages...");
 
-                let files = fileInput.files;
+        const pages = FPDF.GetPageCount(doc.processor.wasmData.wasm);
+        console.log("Pages: " + pages);
 
-                if (files.length <= 0) {
-                    throw { message: "Select a PDF file or type a public PDF url" };
-                }
+        // list all pages
+        if (pages > 0) {
+          console.log("Rendering " + pages + " PDF pages...");
 
-                let file = files[0];
+          doc.setPages(pages);
+          doc.createAllPages();
 
-                let fileByteArray = await fileToByteArray(file);
+          for (let x = 0; x < pages; x++) {
+            console.log("Rendering page " + (x + 1) + "...");
 
-                if (fileByteArray.length <= 0) {
-                    throw { message: "The PDF file is invalid" };
-                }
+            // render to canvas
+            console.log("Rendering to canvas...");
 
-                changeButton('Processing file...', 'warning');
+            // add page item
+            console.log("Adding page item...");
 
-                setTimeout(function () {
-                    processPDF(fileByteArray);
-                }, 300);
-            } catch (error) {
-                changeButton('Error while load file', 'danger');
-                console.log('Error while load file: ' + error.message);
+            const image = doc.getPage(x).createImage();
+
+            // add content item
+            const content = document.createElement("div");
+            content.className = "content";
+            content.appendChild(image);
+
+            // add loader content
+            const loaderContent = document.createElement("span");
+            loaderContent.className = "loader";
+
+            // add loader
+            const loader = document.createElement("div");
+            loader.className = "page-loader-wrapper";
+            loader.appendChild(loaderContent);
+            content.appendChild(loader);
+
+            // add card
+            const cardContent = document.createElement("div");
+            cardContent.className = "card-content";
+            cardContent.appendChild(content);
+
+            const card = document.createElement("div");
+            card.className = "card";
+            card.appendChild(cardContent);
+
+            const cell = document.createElement("div");
+            cell.className = "cell";
+            cell.style.position = "relative";
+            cell.appendChild(card);
+
+            pageList.appendChild(cell);
+
+            // show results
+            console.log("Page " + (x + 1) + " rendered");
+          }
+
+          const firstPage = await doc.getPage(0);
+          firstPage.render();
+
+          pageListTitle.innerHTML = "Number of pages: " + pages;
+
+          pageListContainer.style.display = "block";
+
+          if (autoOpenMode) {
+            showPageItem(currentPageIndex);
+          }
+
+          showFileForm(false);
+
+          setTimeout(() => {
+            console.log("Scrolling to top...");
+            scrollToTop();
+          }, 100);
+        } else {
+          console.log("Cannot render PDF pages: PDF is empty");
+        }
+
+        // clean memory
+        console.log("Cleaning objects...");
+
+        // initial state
+        buttonToInitialState();
+
+        console.log("Finished");
+      } catch (error) {
+        changeButton("Error while process PDF", "danger");
+        console.log("Error while process PDF: " + error.message);
+      }
+    }
+
+    function fileToByteArray(file) {
+      return new Promise((resolve, reject) => {
+        try {
+          const reader = new FileReader();
+          const fileByteArray = [];
+
+          reader.readAsArrayBuffer(file);
+          reader.onloadend = (evt) => {
+            if (evt.target.readyState == FileReader.DONE) {
+              const arrayBuffer = evt.target.result,
+                array = new Uint8Array(arrayBuffer);
+              for (byte of array) {
+                fileByteArray.push(byte);
+              }
             }
+            resolve(fileByteArray);
+          };
+        } catch (e) {
+          reject(e);
         }
+      });
+    }
 
-        async function loadFileFromURL(url) {
-            try {
-                changeButton('Loading file from URL...', 'warning');
+    function changeButton(text, className) {
+      const btRun = document.getElementById("btRun");
+      btRun.firstChild.data = text;
+      btRun.className = "button is-" + className;
+    }
 
-                resetOnLoad();
+    function getUrlParam(param) {
+      const params = getAllUrlParams(window.location.href);
 
-                let response = await fetch(url);
-                let fileBuffer = await response.arrayBuffer();
-                let fileByteArray = new Uint8Array(fileBuffer);
+      if (
+        params != null &&
+        params !== undefined &&
+        Object.hasOwn(params, param)
+      ) {
+        const value = params[param];
 
-                if (fileByteArray.length <= 0) {
-                    throw { message: "The PDF file is invalid" };
-                }
+        if (value != null && value !== undefined) {
+          return value;
+        }
+      }
 
-                changeButton('Processing file...', 'warning');
+      return null;
+    }
 
-                setTimeout(function () {
-                    processPDF(fileByteArray);
-                }, 300);
-            } catch (error) {
-                changeButton('Error while load file from URL', 'danger');
-                console.log('Error while load file from URL: ' + error.message);
+    function getAllUrlParams(url) {
+      // get query string from url (optional) or window
+      var queryString = url
+        ? url.split("?")[1]
+        : window.location.search.slice(1);
+
+      // we'll store the parameters here
+      var obj = {};
+
+      // if query string exists
+      if (queryString) {
+        // stuff after # is not part of query string, so get rid of it
+        queryString = queryString.split("#")[0];
+
+        // split our query string into its component parts
+        var arr = queryString.split("&");
+
+        for (var i = 0; i < arr.length; i++) {
+          // separate the keys and the values
+          var a = arr[i].split("=");
+
+          // in case params look like: list[]=thing1&list[]=thing2
+          var paramNum;
+          var paramName = a[0].replace(/\[\d*\]/, (v) => {
+            paramNum = v.slice(1, -1);
+            return "";
+          });
+
+          // set parameter value (use 'true' if empty)
+          var paramValue = typeof a[1] === "undefined" ? true : a[1];
+
+          // if parameter name already exists
+          if (obj[paramName]) {
+            // convert value to array (if still string)
+            if (typeof obj[paramName] === "string") {
+              obj[paramName] = [obj[paramName]];
             }
-        }
-
-        async function processPDF(fileByteArray) {
-            try {
-                // html general
-                changeButton('Processing file...', 'warning');
-
-                let pageListContainer = document.getElementById('pageListContainer');
-                let pageList = document.getElementById('pageList');
-                let pageListTitle = document.getElementById('pageListTitle');
-
-                pageListContainer.style.display = "none";
-                pageList.innerHTML = "";
-
-                // check file size
-                console.log('Getting file size...');
-
-                let fileSize = fileByteArray.length;
-                console.log("File size: " + fileSize + " bytes");
-
-                // init library
-                console.log('Initializing library...');
-
-                FPDF.Init();
-
-                // load document to memory
-                console.log('Loading data to buffer...');
-
-                let wasmBuffer = Module.wasmExports.malloc(fileSize);
-                Module.HEAPU8.set(fileByteArray, wasmBuffer);
-
-                // create document
-                console.log('Loading document...');
-
-                doc = new Doc({
-                    wasm: FPDF.LoadMemDocument(wasmBuffer, fileSize, ""),
-                    wasmBuffer: wasmBuffer,
-                });
-
-                // check last error
-                let lastError = doc.processor.getLastError();
-                console.log("Load document state: " + lastError);
-
-                // count page
-                console.log('Couting pages...');
-
-                let pages = FPDF.GetPageCount(doc.processor.wasmData.wasm);
-                console.log('Pages: ' + pages);
-
-                // list all pages
-                if (pages > 0) {
-                    console.log('Rendering ' + pages + ' PDF pages...');
-
-                    doc.setPages(pages);
-                    doc.createAllPages();
-
-                    for (let x = 0; x < pages; x++) {
-                        console.log('Rendering page ' + (x + 1) + '...');
-
-                        // render to canvas
-                        console.log("Rendering to canvas...");
-
-                        // add page item
-                        console.log("Adding page item...");
-
-                        const image = doc.getPage(x).createImage();
-
-                        // add content item
-                        let content = document.createElement('div');
-                        content.className = "content";
-                        content.appendChild(image);
-
-                        // add loader content
-                        let loaderContent = document.createElement('span');
-                        loaderContent.className = "loader";
-
-                        // add loader
-                        let loader = document.createElement('div');
-                        loader.className = "page-loader-wrapper";
-                        loader.appendChild(loaderContent);
-                        content.appendChild(loader);
-
-                        // add card
-                        let cardContent = document.createElement('div');
-                        cardContent.className = "card-content";
-                        cardContent.appendChild(content);
-
-                        let card = document.createElement('div');
-                        card.className = "card";
-                        card.appendChild(cardContent);
-
-                        let cell = document.createElement('div');
-                        cell.className = "cell";
-                        cell.style.position = "relative";
-                        cell.appendChild(card);
-
-                        pageList.appendChild(cell);
-
-                        // show results
-                        console.log('Page ' + (x + 1) + ' rendered');
-                    }
-
-                    let firstPage = await doc.getPage(0);
-                    firstPage.render();
-
-                    pageListTitle.innerHTML = "Number of pages: " + pages;
-
-                    pageListContainer.style.display = "block";
-
-                    if (autoOpenMode) {
-                        showPageItem(currentPageIndex);
-                    }
-
-                    showFileForm(false);
-
-                    setTimeout(function () {
-                        console.log('Scrolling to top...');
-                        scrollToTop();
-                    }, 100);
-                } else {
-                    console.log('Cannot render PDF pages: PDF is empty');
-                }
-
-                // clean memory
-                console.log('Cleaning objects...');
-
-                // initial state
-                buttonToInitialState();
-
-                console.log('Finished');
-            } catch (error) {
-                changeButton('Error while process PDF', 'danger');
-                console.log('Error while process PDF: ' + error.message);
+            // if no array index number specified...
+            if (typeof paramNum === "undefined") {
+              // put the value on the end of the array
+              obj[paramName].push(paramValue);
             }
-        }
-
-        function fileToByteArray(file) {
-            return new Promise((resolve, reject) => {
-                try {
-                    let reader = new FileReader();
-                    let fileByteArray = [];
-
-                    reader.readAsArrayBuffer(file);
-                    reader.onloadend = (evt) => {
-                        if (evt.target.readyState == FileReader.DONE) {
-                            let arrayBuffer = evt.target.result,
-                                array = new Uint8Array(arrayBuffer);
-                            for (byte of array) {
-                                fileByteArray.push(byte);
-                            }
-                        }
-                        resolve(fileByteArray);
-                    }
-                }
-                catch (e) {
-                    reject(e);
-                }
-            })
-        }
-
-        function changeButton(text, className) {
-            let btRun = document.getElementById('btRun');
-            btRun.firstChild.data = text;
-            btRun.className = 'button is-' + className;
-        }
-
-        function getUrlParam(param) {
-            let params = getAllUrlParams(window.location.href);
-
-            if (params != null && params !== undefined) {
-                if (params.hasOwnProperty(param)) {
-                    let value = params[param];
-
-                    if (value != null && value !== undefined) {
-                        return value;
-                    }
-                }
+            // if array index number specified...
+            else {
+              // put the value at that index number
+              obj[paramName][paramNum] = paramValue;
             }
-
-            return null;
+          }
+          // if param name doesn't exist yet, set it
+          else {
+            obj[paramName] = paramValue;
+          }
         }
+      }
 
-        function getAllUrlParams(url) {
-            // get query string from url (optional) or window
-            var queryString = url ? url.split('?')[1] : window.location.search.slice(1);
+      return obj;
+    }
 
-            // we'll store the parameters here
-            var obj = {};
+    function buttonToInitialState() {
+      changeButton("Process file", "success");
+    }
 
-            // if query string exists
-            if (queryString) {
+    function changeFileTitle(title) {
+      const fileTitle = document.getElementById("fileTitle");
+      fileTitle.innerHTML = decodeURI(title);
+    }
 
-                // stuff after # is not part of query string, so get rid of it
-                queryString = queryString.split('#')[0];
+    function changePageTitle(title) {
+      document.title = decodeURI(title) + " - PDF Viewer";
+    }
 
-                // split our query string into its component parts
-                var arr = queryString.split('&');
+    function showDebugConsole(show) {
+      const debugConsole = document.getElementById("debugConsole");
 
-                for (var i = 0; i < arr.length; i++) {
-                    // separate the keys and the values
-                    var a = arr[i].split('=');
+      if (show) {
+        debugConsole.style.display = "block";
+      } else {
+        debugConsole.style.display = "none";
+      }
+    }
 
-                    // in case params look like: list[]=thing1&list[]=thing2
-                    var paramNum = undefined;
-                    var paramName = a[0].replace(/\[\d*\]/, function (v) {
-                        paramNum = v.slice(1, -1);
-                        return '';
-                    });
+    function showFileTitle(show) {
+      const fileTitle = document.getElementById("fileTitle");
 
-                    // set parameter value (use 'true' if empty)
-                    var paramValue = typeof (a[1]) === 'undefined' ? true : a[1];
+      if (show) {
+        fileTitle.style.display = "block";
+      } else {
+        fileTitle.style.display = "none";
+      }
+    }
 
-                    // if parameter name already exists
-                    if (obj[paramName]) {
-                        // convert value to array (if still string)
-                        if (typeof obj[paramName] === 'string') {
-                            obj[paramName] = [obj[paramName]];
-                        }
-                        // if no array index number specified...
-                        if (typeof paramNum === 'undefined') {
-                            // put the value on the end of the array
-                            obj[paramName].push(paramValue);
-                        }
-                        // if array index number specified...
-                        else {
-                            // put the value at that index number
-                            obj[paramName][paramNum] = paramValue;
-                        }
-                    }
-                    // if param name doesn't exist yet, set it
-                    else {
-                        obj[paramName] = paramValue;
-                    }
-                }
-            }
+    function showFileForm(show) {
+      const fileForm = document.getElementById("fileForm");
 
-            return obj;
-        }
+      if (show) {
+        fileForm.style.display = "block";
+      } else {
+        fileForm.style.display = "none";
+      }
+    }
 
-        function buttonToInitialState() {
-            changeButton('Process file', 'success');
-        }
+    function showLoading(show) {
+      const loading = document.getElementById("loadingContainer");
 
-        function changeFileTitle(title) {
-            let fileTitle = document.getElementById('fileTitle');
-            fileTitle.innerHTML = decodeURI(title);
-        }
+      if (show) {
+        loading.className = "loader-wrapper is-active";
+      } else {
+        loading.className = "loader-wrapper";
+      }
 
-        function changePageTitle(title) {
-            document.title = decodeURI(title) + " - PDF Viewer";
-        }
+      return false;
+    }
 
-        function showDebugConsole(show) {
-            let debugConsole = document.getElementById('debugConsole');
+    function showFooter(show) {
+      const footer = document.getElementById("footer");
 
-            if (show) {
-                debugConsole.style.display = "block";
-            } else {
-                debugConsole.style.display = "none";
-            }
-        }
+      if (show) {
+        footer.style.display = "block";
+      } else {
+        footer.style.display = "none";
+      }
+    }
 
-        function showFileTitle(show) {
-            let fileTitle = document.getElementById('fileTitle');
+    function scrollToTop() {
+      window.scrollTo({ top: 0 });
+    }
 
-            if (show) {
-                fileTitle.style.display = "block";
-            } else {
-                fileTitle.style.display = "none";
-            }
-        }
+    function openModal() {
+      const modal = document.getElementById("pageModal");
 
-        function showFileForm(show) {
-            let fileForm = document.getElementById('fileForm');
+      if (typeof modal != "undefined") {
+        modal.className = "modal is-active";
+      }
+    }
 
-            if (show) {
-                fileForm.style.display = "block";
-            } else {
-                fileForm.style.display = "none";
-            }
-        }
+    function closeModal() {
+      const modal = document.getElementById("pageModal");
 
-        function showLoading(show) {
-            let loading = document.getElementById('loadingContainer');
+      if (typeof modal != "undefined") {
+        modal.className = "modal";
+      }
 
-            if (show) {
-                loading.className = "loader-wrapper is-active";
-            } else {
-                loading.className = "loader-wrapper";
-            }
+      setTimeout(() => {
+        doc.renderPages();
+      }, 500);
+    }
 
-            return false;
-        }
+    function modalIsOpened() {
+      const modal = document.getElementById("pageModal");
 
-        function showFooter(show) {
-            let footer = document.getElementById('footer');
+      if (modal.classList.contains("is-active")) {
+        return true;
+      }
 
-            if (show) {
-                footer.style.display = "block";
-            } else {
-                footer.style.display = "none";
-            }
-        }
+      return false;
+    }
 
-        function scrollToTop() {
-            window.scrollTo({ top: 0 })
-        }
+    function changeCurrentPageItemPlus(n) {
+      showPageItem((currentPageIndex += n));
+    }
 
-        function openModal() {
-            let modal = document.getElementById('pageModal');
+    function changeCurrentPageItem(index) {
+      showPageItem(index);
+    }
 
-            if (typeof modal != "undefined") {
-                modal.className = "modal is-active";
-            }
-        }
+    function showPageItem(index) {
+      const pages = document.getElementsByClassName("page-list-item");
+      const pageModalImage = document.getElementById("pageModalImage");
 
-        function closeModal() {
-            let modal = document.getElementById('pageModal');
+      if (index > pages.length) {
+        currentPageIndex = pages.length;
+      } else if (index < 1) {
+        currentPageIndex = 1;
+      } else {
+        currentPageIndex = index;
+      }
 
-            if (typeof modal != "undefined") {
-                modal.className = "modal";
+      const currentPage = doc.getPage(currentPageIndex - 1);
+      if (!currentPage.loaded) {
+        currentPage.render();
+      }
+
+      const page = pages[currentPageIndex - 1];
+
+      if (typeof page != "undefined") {
+        pageModalImage.src = page.src;
+      }
+
+      const prevLink = document.querySelector(".page-prev");
+      const nextLink = document.querySelector(".page-next");
+      if (currentPageIndex === 1) {
+        prevLink.classList.add("disabled");
+      } else {
+        prevLink.classList.remove("disabled");
+      }
+      if (currentPageIndex === pages.length) {
+        nextLink.classList.add("disabled");
+      } else {
+        nextLink.classList.remove("disabled");
+      }
+
+      openModal();
+    }
+
+    function resetOnLoad() {
+      currentPageIndex = 1;
+    }
+
+    function bindKeys() {
+      document.onkeydown = (e) => {
+        switch (e.which) {
+          case 27:
+            // esc
+            if (modalIsOpened()) {
+              closeModal();
+              e.preventDefault();
             }
 
-            setTimeout(function () {
-                doc.renderPages();
-            }, 500)
+            break;
+
+          case 37:
+            // left
+            if (modalIsOpened()) {
+              changeCurrentPageItemPlus(-1);
+              e.preventDefault();
+            }
+
+            break;
+
+          case 39:
+            // right
+            if (modalIsOpened()) {
+              changeCurrentPageItemPlus(1);
+              e.preventDefault();
+            }
+
+            break;
+
+          default:
+            return;
         }
+      };
+    }
 
-        function modalIsOpened() {
-            let modal = document.getElementById('pageModal');
+    function checkIfEverythingWasLoaded() {
+      if (pageLoaded && moduleLoaded) {
+        startApp();
+      }
+    }
 
-            if (modal.classList.contains("is-active")) {
-                return true;
-            }
-
-            return false;
+    function startUI() {
+      // change console methods
+      if (typeof console != "undefined") {
+        if (typeof console.log != "undefined") {
+          console.olog = console.log;
+        } else {
+          console.olog = () => {};
         }
+      }
 
-        function changeCurrentPageItemPlus(n) {
-            showPageItem(currentPageIndex += n);
+      console.log = (message) => {
+        // we will disable it for now
+        // console.olog(message);
+
+        var currentDate = new Date().toLocaleTimeString();
+
+        var e = document.createElement("p");
+        e.innerHTML = "➔ [" + currentDate + "] " + message;
+
+        document.getElementById("debugConsoleContent").prepend(e);
+      };
+
+      console.error = console.debug = console.info = console.log;
+
+      // check for wasm support
+      if (!("WebAssembly" in window)) {
+        console.log("You need a browser with Web Assembly support enabled :(");
+        changeButton("Web Assembly not supported", "danger");
+        return;
+      }
+
+      // file input
+      var fileInput = document.querySelector(
+        "#file-container input[type=file]"
+      );
+      fileInput.onchange = () => {
+        if (fileInput.files.length > 0) {
+          var fileName = document.querySelector("#file-container .file-name");
+          fileName.textContent = fileInput.files[0].name;
         }
+      };
 
-        function changeCurrentPageItem(index) {
-            showPageItem(index);
+      // initial state
+      bindKeys();
+      buttonToInitialState();
+    }
+
+    function initializeFPDF() {
+      FPDF.Init = Module.cwrap("PDFium_Init");
+      FPDF.RenderPageBitmap = Module.cwrap("FPDF_RenderPageBitmap", "", [
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+      ]);
+
+      FPDF.Bitmap_FillRect = Module.cwrap("FPDFBitmap_FillRect", "", [
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+      ]);
+      FPDF.Bitmap_CreateEx = Module.cwrap("FPDFBitmap_CreateEx", "number", [
+        "number",
+        "number",
+        "number",
+        "number",
+        "number",
+      ]);
+      FPDF.Bitmap_Destroy = Module.cwrap("FPDFBitmap_Destroy", "", ["number"]);
+
+      FPDF.LoadPage = Module.cwrap("FPDF_LoadPage", "number", [
+        "number",
+        "number",
+      ]);
+      FPDF.ClosePage = Module.cwrap("FPDF_ClosePage", "", ["number"]);
+
+      FPDF.LoadMemDocument = Module.cwrap("FPDF_LoadMemDocument", "number", [
+        "number",
+        "number",
+        "string",
+      ]);
+      FPDF.GetPageSizeByIndex = Module.cwrap(
+        "FPDF_GetPageSizeByIndex",
+        "number",
+        ["number", "number", "number", "number"]
+      );
+      FPDF.GetLastError = Module.cwrap("FPDF_GetLastError", "number");
+      FPDF.GetPageCount = Module.cwrap("FPDF_GetPageCount", "number", [
+        "number",
+      ]);
+      FPDF.CloseDocument = Module.cwrap("FPDF_CloseDocument", "", ["number"]);
+      FPDF.DestroyLibrary = Module.cwrap("FPDF_DestroyLibrary");
+
+      window.heap = (J, s) => {
+        let E;
+        switch (J) {
+          case Int8Array:
+            E = Module.HEAP8;
+            break;
+          case Int16Array:
+            E = Module.HEAP16;
+            break;
+          case Int32Array:
+            E = Module.HEAP32;
+            break;
+          case Uint8Array:
+            E = Module.HEAPU8;
+            break;
+          case Uint16Array:
+            E = Module.HEAPU16;
+            break;
+          case Uint32Array:
+            E = Module.HEAPU32;
+            break;
+          case Float32Array:
+            E = Module.HEAPF32;
+            break;
+          case Float64Array:
+            E = Module.HEAPF64;
+            break;
         }
+        const Z = J.BYTES_PER_ELEMENT;
+        const m = Module.wasmExports.malloc(s * Z);
+        const a = Array(1 + s);
+        a[0] = { s, J, Z, E, m, free: () => Module.wasmExports.free(m) };
+        for (let i = 0; i < s; i++)
+          a[i + 1] = {
+            p: m + i * Z,
+            get v() {
+              return E[m / Z + i];
+            },
+          };
+        return a;
+      };
+    }
 
-        function showPageItem(index) {
-            let pages = document.getElementsByClassName("page-list-item");
-            let pageModalImage = document.getElementById("pageModalImage");
+    function startApp() {
+      // initialize FPDF
+      initializeFPDF();
 
-            if (index > pages.length) {
-                currentPageIndex = pages.length;
-            } else if (index < 1) {
-                currentPageIndex = 1;
-            } else {
-                currentPageIndex = index;
-            }
+      // let button start load files
+      const btRun = document.getElementById("btRun");
+      btRun.onclick = () => {
+        const urlInput = document.getElementById("urlInput");
+        const url = urlInput.value;
 
-            let currentPage = doc.getPage(currentPageIndex - 1);
-            if (!currentPage.loaded) {
-                currentPage.render();
-            }
-
-            let page = pages[currentPageIndex - 1];
-
-            if (typeof page != "undefined") {
-                pageModalImage.src = page.src;
-            }
-
-            const prevLink = document.querySelector('.page-prev');
-            const nextLink = document.querySelector('.page-next');
-            if (currentPageIndex === 1) {
-                prevLink.classList.add('disabled')
-            } else {
-                prevLink.classList.remove('disabled')
-            }
-            if (currentPageIndex === pages.length) {
-                nextLink.classList.add('disabled')
-            } else {
-                nextLink.classList.remove('disabled')
-            }
-
-            openModal();
+        if (url.length > 0) {
+          loadFileFromURL(url);
+        } else {
+          loadFile();
         }
+      };
 
-        function resetOnLoad() {
-            currentPageIndex = 1;
-        }
+      // load data from url
+      const urlParamTitle = getUrlParam("title");
+      const urlParamUrl = getUrlParam("url");
+      const urlParamDebug = getUrlParam("debug");
+      const urlParamOpen = getUrlParam("open");
 
-        function bindKeys() {
-            document.onkeydown = function (e) {
-                switch (e.which) {
-                    case 27:
-                        // esc
-                        if (modalIsOpened()) {
-                            closeModal();
-                            e.preventDefault();
-                        }
+      if (urlParamDebug && urlParamDebug === "1") {
+        debugMode = true;
+      } else {
+        debugMode = false;
+      }
 
-                        break;
+      if (urlParamOpen && urlParamOpen === "0") {
+        autoOpenMode = false;
+      } else {
+        autoOpenMode = true;
+      }
 
-                    case 37:
-                        // left
-                        if (modalIsOpened()) {
-                            changeCurrentPageItemPlus(-1)
-                            e.preventDefault();
-                        }
+      if (urlParamTitle) {
+        changeFileTitle(urlParamTitle);
+        changePageTitle(urlParamTitle);
+      }
 
-                        break;
+      if (urlParamUrl) {
+        const urlInput = document.getElementById("urlInput");
+        urlParamUrl.value = urlParamUrl;
 
-                    case 39:
-                        // right
-                        if (modalIsOpened()) {
-                            changeCurrentPageItemPlus(1)
-                            e.preventDefault();
-                        }
+        loadFileFromURL(decodeURI(urlParamUrl));
+      }
 
-                        break;
+      // show inicial things
+      showDebugConsole(debugMode);
+      showFileTitle(true);
+      showFileForm(true);
+      showFooter(true);
 
-                    default: return;
-                }
-            };
-        }
+      setTimeout(() => {
+        showLoading(false);
+      }, 500);
+    }
 
-        function checkIfEverythingWasLoaded() {
-            if (pageLoaded && moduleLoaded) {
-                startApp();
-            }
-        }
+    window.onload = (e) => {
+      pageLoaded = true;
 
-        function startUI() {
-            // change console methods
-            if (typeof console != "undefined") {
-                if (typeof console.log != 'undefined') {
-                    console.olog = console.log;
-                } else {
-                    console.olog = function () { };
-                }
-            }
+      startUI();
 
-            console.log = function (message) {
-                // we will disable it for now
-                // console.olog(message);
+      console.log("The page was loaded!");
 
-                var currentDate = new Date().toLocaleTimeString();
-
-                var e = document.createElement('p');
-                e.innerHTML = "➔ [" + currentDate + "] " + message;
-
-                document.getElementById('debugConsoleContent').prepend(e);
-            };
-
-            console.error = console.debug = console.info = console.log;
-
-            // check for wasm support
-            if (!('WebAssembly' in window)) {
-                console.log('You need a browser with Web Assembly support enabled :(');
-                changeButton('Web Assembly not supported', 'danger');
-                return;
-            }
-
-            // file input
-            var fileInput = document.querySelector('#file-container input[type=file]');
-            fileInput.onchange = () => {
-                if (fileInput.files.length > 0) {
-                    var fileName = document.querySelector('#file-container .file-name');
-                    fileName.textContent = fileInput.files[0].name;
-                }
-            }
-
-            // initial state
-            bindKeys();
-            buttonToInitialState();
-        }
-
-        function initializeFPDF() {
-            FPDF.Init = Module.cwrap('PDFium_Init');
-            FPDF.RenderPageBitmap = Module.cwrap('FPDF_RenderPageBitmap', '', ['number', 'number', 'number', 'number', 'number', 'number', 'number', 'number']);
-
-            FPDF.Bitmap_FillRect = Module.cwrap('FPDFBitmap_FillRect', '', ['number', 'number', 'number', 'number', 'number', 'number']);
-            FPDF.Bitmap_CreateEx = Module.cwrap('FPDFBitmap_CreateEx', 'number', ['number', 'number', 'number', 'number', 'number']);
-            FPDF.Bitmap_Destroy = Module.cwrap('FPDFBitmap_Destroy', '', ['number']);
-
-            FPDF.LoadPage = Module.cwrap('FPDF_LoadPage', 'number', ['number', 'number']);
-            FPDF.ClosePage = Module.cwrap('FPDF_ClosePage', '', ['number']);
-
-            FPDF.LoadMemDocument = Module.cwrap('FPDF_LoadMemDocument', 'number', ['number', 'number', 'string']);
-            FPDF.GetPageSizeByIndex = Module.cwrap('FPDF_GetPageSizeByIndex', 'number', ['number', 'number', 'number', 'number']);
-            FPDF.GetLastError = Module.cwrap('FPDF_GetLastError', 'number');
-            FPDF.GetPageCount = Module.cwrap('FPDF_GetPageCount', 'number', ['number']);
-            FPDF.CloseDocument = Module.cwrap('FPDF_CloseDocument', '', ['number']);
-            FPDF.DestroyLibrary = Module.cwrap('FPDF_DestroyLibrary');
-
-            window.heap = (J, s) => {
-                let E;
-                switch (J) {
-                    case Int8Array: E = Module.HEAP8; break;
-                    case Int16Array: E = Module.HEAP16; break;
-                    case Int32Array: E = Module.HEAP32; break;
-                    case Uint8Array: E = Module.HEAPU8; break;
-                    case Uint16Array: E = Module.HEAPU16; break;
-                    case Uint32Array: E = Module.HEAPU32; break;
-                    case Float32Array: E = Module.HEAPF32; break;
-                    case Float64Array: E = Module.HEAPF64; break;
-                }
-                const Z = J.BYTES_PER_ELEMENT; const m = Module.wasmExports.malloc(s * Z);
-                const a = Array(1 + s); a[0] = ({ s, J, Z, E, m, free: () => Module.wasmExports.free(m) });
-                for (let i = 0; i < s; i++) a[i + 1] = ({ p: m + (i * Z), get v() { return E[m / Z + i]; } });
-                return a;
-            };
-        }
-
-        function startApp() {
-            // initialize FPDF
-            initializeFPDF();
-
-            // let button start load files
-            let btRun = document.getElementById('btRun');
-            btRun.onclick = function () {
-                let urlInput = document.getElementById('urlInput');
-                let url = urlInput.value;
-
-                if (url.length > 0) {
-                    loadFileFromURL(url);
-                } else {
-                    loadFile();
-                }
-            }
-
-            // load data from url
-            let urlParamTitle = getUrlParam("title");
-            let urlParamUrl = getUrlParam("url");
-            let urlParamDebug = getUrlParam("debug");
-            let urlParamOpen = getUrlParam("open");
-
-            if (urlParamDebug && urlParamDebug === "1") {
-                debugMode = true;
-            } else {
-                debugMode = false;
-            }
-
-            if (urlParamOpen && urlParamOpen === "0") {
-                autoOpenMode = false;
-            } else {
-                autoOpenMode = true;
-            }
-
-            if (urlParamTitle) {
-                changeFileTitle(urlParamTitle);
-                changePageTitle(urlParamTitle);
-            }
-
-            if (urlParamUrl) {
-                let urlInput = document.getElementById('urlInput');
-                urlParamUrl.value = urlParamUrl;
-
-                loadFileFromURL(decodeURI(urlParamUrl));
-            }
-
-            // show inicial things
-            showDebugConsole(debugMode);
-            showFileTitle(true);
-            showFileForm(true);
-            showFooter(true);
-
-            setTimeout(function () {
-                showLoading(false);
-            }, 500);
-        }
-
-        window.onload = function (e) {
-            pageLoaded = true;
-
-            startUI();
-
-            console.log('The page was loaded!');
-
-            checkIfEverythingWasLoaded();
-        }
+      checkIfEverythingWasLoaded();
+    };
     </script>
 
     <style>
-        /* general */
-        body {
-            touch-action: pan-x pan-y;
-            display: flex;
-            min-height: 100vh;
-            flex-direction: column;
-        }
+    /* general */
+    body {
+      touch-action: pan-x pan-y;
+      display: flex;
+      min-height: 100vh;
+      flex-direction: column;
+    }
 
-        .section {
-            flex: 1;
-        }
+    .section {
+      flex: 1;
+    }
 
-        .footer {
-            padding-bottom: 1.5rem;
-            padding-top: 1.5rem;
-            display: none;
-        }
+    .footer {
+      padding-bottom: 1.5rem;
+      padding-top: 1.5rem;
+      display: none;
+    }
 
-        /* page list item */
-        .page-list-item {
-            box-sizing: border-box;
-            display: flex;
-            justify-content: center;
-            padding: 2px;
-            cursor: pointer;
-        }
+    /* page list item */
+    .page-list-item {
+      box-sizing: border-box;
+      display: flex;
+      justify-content: center;
+      padding: 2px;
+      cursor: pointer;
+    }
 
-        /* modal */
-        .modal {
-            display: none;
-            position: fixed;
-            z-index: 1;
-            left: 0;
-            top: 0;
-            width: 100%;
-            height: 100%;
-            background-color: rgba(0, 0, 0, 0.5);
-        }
+    /* modal */
+    .modal {
+      display: none;
+      position: fixed;
+      z-index: 1;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      background-color: rgba(0, 0, 0, 0.5);
+    }
 
-        .modal-content {
-            max-height: none !important;
-            overflow: hidden;
-            width: 78%;
-            text-align: center;
-        }
+    .modal-content {
+      max-height: none !important;
+      overflow: hidden;
+      width: 78%;
+      text-align: center;
+    }
 
-        /* next & previous buttons */
-        .page-prev,
-        .page-next {
-            cursor: pointer;
-            position: absolute;
-            top: 50%;
-            width: auto;
-            padding: 16px;
-            margin-top: -34px;
-            color: white;
-            font-weight: bold;
-            font-size: 20px;
-            transition: 0.6s ease;
-            border-radius: 0 3px 3px 0;
-            user-select: none;
-            -webkit-user-select: none;
-        }
+    /* next & previous buttons */
+    .page-prev,
+    .page-next {
+      cursor: pointer;
+      position: absolute;
+      top: 50%;
+      width: auto;
+      padding: 16px;
+      margin-top: -34px;
+      color: white;
+      font-weight: bold;
+      font-size: 20px;
+      transition: 0.6s ease;
+      border-radius: 0 3px 3px 0;
+      user-select: none;
+      -webkit-user-select: none;
+    }
 
-        .page-prev.disabled,
-        .page-next.disabled {
-            cursor: not-allowed;
-            color: unset;
-        }
+    .page-prev.disabled,
+    .page-next.disabled {
+      cursor: not-allowed;
+      color: unset;
+    }
 
-        .page-next {
-            right: 0;
-            border-radius: 3px 0 0 3px;
-        }
+    .page-next {
+      right: 0;
+      border-radius: 3px 0 0 3px;
+    }
 
-        .page-prev {
-            left: 0;
-            border-radius: 3px 0 0 3px;
-        }
+    .page-prev {
+      left: 0;
+      border-radius: 3px 0 0 3px;
+    }
 
-        /* page list */
-        #pageList .card-content {
-            padding: 0;
-        }
+    /* page list */
+    #pageList .card-content {
+      padding: 0;
+    }
 
-        .page-loader-wrapper {
-            padding: 30px 10px;
-        }
+    .page-loader-wrapper {
+      padding: 30px 10px;
+    }
 
-        .page-loader-wrapper .loader {
-            -webkit-animation: spinAround .5s infinite linear;
-            animation: spinAround .5s infinite linear;
-            border: 2px solid #dbdbdb;
-            border-radius: 9999px;
-            border-right-color: transparent;
-            border-top-color: transparent;
-            content: "";
-            display: block;
-            height: 2em;
-            width: 2em;
-        }
+    .page-loader-wrapper .loader {
+      -webkit-animation: spinAround 0.5s infinite linear;
+      animation: spinAround 0.5s infinite linear;
+      border: 2px solid #dbdbdb;
+      border-radius: 9999px;
+      border-right-color: transparent;
+      border-top-color: transparent;
+      content: "";
+      display: block;
+      height: 2em;
+      width: 2em;
+    }
 
-        /*  modal */
-        .modal-close {
-            margin-right: -12px;
-        }
+    /*  modal */
+    .modal-close {
+      margin-right: -12px;
+    }
 
-        /* page list container */
-        #pageListContainer {
-            margin-bottom: 30px;
-            display: none;
-        }
+    /* page list container */
+    #pageListContainer {
+      margin-bottom: 30px;
+      display: none;
+    }
 
-        /* page title */
-        #pageListTitle {
-            margin-bottom: 24px;
-            font-weight: bold;
-        }
+    /* page title */
+    #pageListTitle {
+      margin-bottom: 24px;
+      font-weight: bold;
+    }
 
-        /* page modal image */
-        #pageModalImage {
-            max-height: 100%;
-        }
+    /* page modal image */
+    #pageModalImage {
+      max-height: 100%;
+    }
 
-        /* loader */
-        .loader-wrapper {
-            position: absolute;
-            top: 0;
-            left: 0;
-            height: 100%;
-            width: 100%;
-            background-color: var(--bulma-box-background-color);
-            opacity: 0;
-            z-index: -1;
-            transition: opacity .3s;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            border-radius: 6px;
-        }
+    /* loader */
+    .loader-wrapper {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+      background-color: var(--bulma-box-background-color);
+      opacity: 0;
+      z-index: -1;
+      transition: opacity 0.3s;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border-radius: 6px;
+    }
 
-        .loader {
-            height: 80px;
-            width: 80px;
-            margin: 0 auto;
-        }
+    .loader {
+      height: 80px;
+      width: 80px;
+      margin: 0 auto;
+    }
 
-        .is-active {
-            opacity: 1;
-            z-index: 1;
-        }
+    .is-active {
+      opacity: 1;
+      z-index: 1;
+    }
 
-        /* file title */
-        #fileTitle {
-            display: none;
-        }
+    /* file title */
+    #fileTitle {
+      display: none;
+    }
 
-        /* file form */
-        #fileForm {
-            display: none;
-        }
+    /* file form */
+    #fileForm {
+      display: none;
+    }
     </style>
-</head>
+  </head>
 
-<body>
+  <body>
     <!-- loading -->
     <div id="loadingContainer">
-        <div class="box">
-            <div class="loader-wrapper is-active">
-                <div class="loader is-loading"></div>
-            </div>
+      <div class="box">
+        <div class="loader-wrapper is-active">
+          <div class="loader is-loading"></div>
         </div>
+      </div>
     </div>
 
     <!-- content -->
     <section class="section is-centered">
-        <div class="container">
+      <div class="container">
+        <!-- title -->
+        <h1 id="fileTitle" class="title" style="display: none;">PDF Viewer</h1>
 
-            <!-- title -->
-            <h1 id="fileTitle" class="title" style="display: none;">PDF Viewer</h1>
+        <div id="fileForm" style="display: none;">
+          <br>
+          <p>1 - Select your PDF file:</p>
+          <br>
 
-            <div id="fileForm" style="display: none;">
-                <br>
-                <p>1 - Select your PDF file:</p>
-                <br>
+          <!-- file input -->
+          <div id="file-container" class="file is-info has-name is-boxed">
+            <label class="file-label">
+              <input
+                class="file-input"
+                id="fileInput"
+                type="file"
+                accept="application/pdf"
+              >
+              <span class="file-cta">
+                <span class="file-label"> Choose a file… </span>
+              </span>
+              <span class="file-name"> No file uploaded </span>
+            </label>
+          </div>
+          <br>
+          <br>
 
-                <!-- file input -->
-                <div id="file-container" class="file is-info has-name is-boxed">
-                    <label class="file-label">
-                        <input class="file-input" id="fileInput" type="file" accept="application/pdf">
-                        <span class="file-cta">
-                            <span class="file-label">
-                                Choose a file…
-                            </span>
-                        </span>
-                        <span class="file-name">
-                            No file uploaded
-                        </span>
-                    </label>
-                </div>
-                <br>
-                <br>
+          <!-- url input -->
+          <p>Or type any PDF public url:</p>
+          <br>
+          <input class="input" type="text" placeholder="" id="urlInput">
+          <br>
+          <br>
 
-                <!-- url input -->
-                <p>Or type any PDF public url:</p>
-                <br>
-                <input class="input" type="text" placeholder="" id="urlInput">
-                <br>
-                <br>
-
-                <!-- process button -->
-                <p>2 - Press button to process:</p>
-                <br>
-                <button class="button is-warning" id="btRun">Loading...</button>
-                <br>
-                <br>
-                <br>
-            </div>
-
-            <!-- page list container -->
-            <div id="pageListContainer" style="display: none;">
-                <p style="font-weight: bold;" id="pageListTitle">Number of pages: 0</p>
-
-                <!-- page as a cell -->
-                <div class="fixed-grid has-auto-count">
-                    <div class="grid" id="pageList"></div>
-                </div>
-
-                <div class="modal" id="pageModal">
-                    <div class="modal-background" onclick="closeModal()"></div>
-                    <div class="modal-content">
-                        <img id="pageModalImage" src="">
-                    </div>
-
-                    <!-- modal buttons -->
-                    <a class="page-prev" onclick="changeCurrentPageItemPlus(-1)">&#10094;</a>
-
-                    <a class="page-next" onclick="changeCurrentPageItemPlus(1)">&#10095;</a>
-
-                    <button onclick="closeModal()" class="modal-close is-large" aria-label="close"></button>
-                </div>
-            </div>
-
-            <!-- debug console -->
-            <div class="card" id="debugConsole" style="display: none;">
-                <header class="card-header">
-                    <p class="card-header-title">
-                        Debug console
-                    </p>
-                </header>
-                <div class="card-content">
-                    <div class="content">
-                        <div id="debugConsoleContent">
-                            <p>➔ Debug messages will be showed here</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
+          <!-- process button -->
+          <p>2 - Press button to process:</p>
+          <br>
+          <button class="button is-warning" id="btRun">Loading...</button>
+          <br>
+          <br>
+          <br>
         </div>
 
+        <!-- page list container -->
+        <div id="pageListContainer" style="display: none;">
+          <p style="font-weight: bold;" id="pageListTitle">
+            Number of pages: 0
+          </p>
+
+          <!-- page as a cell -->
+          <div class="fixed-grid has-auto-count">
+            <div class="grid" id="pageList"></div>
+          </div>
+
+          <div class="modal" id="pageModal">
+            <div class="modal-background" onclick="closeModal()"></div>
+            <div class="modal-content">
+              <img id="pageModalImage" src="">
+            </div>
+
+            <!-- modal buttons -->
+            <a class="page-prev" onclick="changeCurrentPageItemPlus(-1)"
+              >&#10094;</a
+            >
+
+            <a class="page-next" onclick="changeCurrentPageItemPlus(1)"
+              >&#10095;</a
+            >
+
+            <button
+              onclick="closeModal()"
+              class="modal-close is-large"
+              aria-label="close"
+            ></button>
+          </div>
+        </div>
+
+        <!-- debug console -->
+        <div class="card" id="debugConsole" style="display: none;">
+          <header class="card-header">
+            <p class="card-header-title">Debug console</p>
+          </header>
+          <div class="card-content">
+            <div class="content">
+              <div id="debugConsoleContent">
+                <p>➔ Debug messages will be showed here</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
 
     <!-- footer -->
     <footer id="footer" class="footer" style="display: none;">
-        <div class="content has-text-centered is-small">
-            <p>
-                This application is powered by an open source project called PDF Viewer and can be found <a
-                    target="_blank" href="https://github.com/paulocoutinhox/pdfium-lib">here</a>. No data is stored and
-                everything run only on client side.
-            </p>
-            <p>
-                PDFium branch "{pdfium-branch}".
-            </p>
-        </div>
+      <div class="content has-text-centered is-small">
+        <p>
+          This application is powered by an open source project called PDF
+          Viewer and can be found
+          <a target="_blank" href="https://github.com/paulocoutinhox/pdfium-lib"
+            >here</a
+          >. No data is stored and everything run only on client side.
+        </p>
+        <p>PDFium branch " { pdfium-branch}".</p>
+      </div>
     </footer>
 
     <!-- google analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J2FWK7KZMQ"></script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-J2FWK7KZMQ"
+    ></script>
     <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
+    "use strict";
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    gtag("js", new Date());
 
-        gtag('config', 'G-J2FWK7KZMQ');
+    gtag("config", "G-J2FWK7KZMQ");
     </script>
-</body>
-
+  </body>
 </html>

--- a/extras/wasm/template/package.json
+++ b/extras/wasm/template/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "pdfium-lib",
-    "version": "{pdfium-branch-version}.0.0",
-    "exports": {
-      ".": {
-        "require": "./node/pdfium.js",
-        "import": "./node/pdfium.esm.js"
-      },
-      "./pdfium.wasm": {
-        "require": "./node/pdfium.wasm",
-        "import": "./node/pdfium.esm.wasm"
-      }
+  "name": "pdfium-lib",
+  "version": "{pdfium-branch-version}.0.0",
+  "exports": {
+    ".": {
+      "require": "./node/pdfium.js",
+      "import": "./node/pdfium.esm.js"
+    },
+    "./pdfium.wasm": {
+      "require": "./node/pdfium.wasm",
+      "import": "./node/pdfium.esm.wasm"
     }
   }
+}

--- a/extras/wasm/utils/function-names.js
+++ b/extras/wasm/utils/function-names.js
@@ -1,15 +1,18 @@
-const fs = require('fs');
-const xpath = require('xpath');
-const { DOMParser } = require('xmldom');
+const fs = require("fs");
+const xpath = require("xpath");
+const { DOMParser } = require("xmldom");
 
 const inputXmlFilename = process.argv[2];
-const extraFunctions = process.argv[3] ? process.argv[3].split(',') : [];
-const inputXmlContent = fs.readFileSync(inputXmlFilename, 'utf-8');
+const extraFunctions = process.argv[3] ? process.argv[3].split(",") : [];
+const inputXmlContent = fs.readFileSync(inputXmlFilename, "utf-8");
 const inputDom = new DOMParser().parseFromString(inputXmlContent);
 const nodes = xpath.select('//member[@kind="function"]/name/text()', inputDom);
 
-const allFunctions = [...nodes.map(node => node.toString()), ...extraFunctions];
+const allFunctions = [
+  ...nodes.map((node) => node.toString()),
+  ...extraFunctions,
+];
 
 console.log(
-  JSON.stringify(allFunctions.map(functionName => '_' + functionName))
+  JSON.stringify(allFunctions.map((functionName) => "_" + functionName))
 );

--- a/extras/wasm/utils/package.json
+++ b/extras/wasm/utils/package.json
@@ -1,10 +1,10 @@
 {
-    "name": "utils",
-    "version": "1.0.0",
-    "main": "index.js",
-    "license": "MIT",
-    "dependencies": {
-        "xmldom": "0.6.0",
-        "xpath": "0.0.32"
-    }
+  "name": "utils",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "xmldom": "0.6.0",
+    "xpath": "0.0.32"
+  }
 }

--- a/extras/wasm/utils/pre-js.js
+++ b/extras/wasm/utils/pre-js.js
@@ -1,7 +1,7 @@
 // This makes sure the generated module is easily able
 // to locate the '.wasm' file when running in node.
 Module = {
-    locateFile: function (name) {
-        return require('path').join(__dirname, name);
-    }
+  locateFile(name) {
+    return require("path").join(__dirname, name);
+  },
 };

--- a/modules/android.py
+++ b/modules/android.py
@@ -48,6 +48,8 @@ def run_task_patch():
     else:
         l.bullet("Skipped: build config", l.PURPLE)
 
+    patch.apply_lumin_custom_patches("android")
+
     l.ok()
 
 

--- a/modules/ios.py
+++ b/modules/ios.py
@@ -84,6 +84,8 @@ def run_task_patch():
     else:
         l.bullet("Skipped: ios automatically manage certs", l.PURPLE)
 
+    patch.apply_lumin_custom_patches("ios")
+
     l.ok()
 
 

--- a/modules/ios.py
+++ b/modules/ios.py
@@ -1,6 +1,9 @@
 import glob
 import os
+import shutil
+import subprocess
 import tarfile
+import tempfile
 
 from pygemstones.io import file as f
 from pygemstones.system import runner as r
@@ -156,19 +159,72 @@ def run_task_build():
                 l.YELLOW,
             )
 
+            out_dir = "out/{0}-{1}-{2}-{3}".format(
+                target["target_os"],
+                target["target_cpu"],
+                target["target_environment"],
+                config,
+            )
+
+            command = ["ninja", "-C", out_dir, "pdfium", "-v"]
+            r.run(command)
+
+            # Build and merge Chromium's custom libc++ into the static archive
+            # so consumers don't get undefined std::__Cr:: symbols at link time.
+            l.colored("Building and merging libc++ / libc++abi...", l.YELLOW)
+
             command = [
                 "ninja",
                 "-C",
-                "out/{0}-{1}-{2}-{3}".format(
-                    target["target_os"],
-                    target["target_cpu"],
-                    target["target_environment"],
-                    config,
-                ),
-                "pdfium",
-                "-v",
+                out_dir,
+                "buildtools/third_party/libc++:libc++",
+                "buildtools/third_party/libc++abi:libc++abi",
             ]
             r.run(command)
+
+            libpdfium = os.path.join(out_dir, "obj", "libpdfium.a")
+            libcxx_obj_dir = os.path.join(
+                out_dir, "obj", "buildtools", "third_party", "libc++", "libc++"
+            )
+            libcxxabi_obj_dir = os.path.join(
+                out_dir, "obj", "buildtools", "third_party", "libc++abi", "libc++abi"
+            )
+
+            objs = glob.glob(os.path.join(libcxx_obj_dir, "*.o"))
+            objs += glob.glob(os.path.join(libcxxabi_obj_dir, "*.o"))
+
+            if objs:
+                # Collect basenames already in the archive so we can detect
+                # collisions (e.g. libc++ thread.o vs openjpeg thread.o).
+                existing = set()
+                try:
+                    result = subprocess.run(
+                        ["ar", "t", libpdfium],
+                        capture_output=True, text=True, check=True,
+                    )
+                    existing = set(result.stdout.strip().splitlines())
+                except Exception:
+                    pass
+
+                # Copy objects to a temp dir, prefixing any that collide.
+                tmp_dir = tempfile.mkdtemp(prefix="libcxx_merge_")
+                try:
+                    staged = []
+                    for obj in objs:
+                        basename = os.path.basename(obj)
+                        if basename in existing:
+                            basename = "libcxx_" + basename
+                        dest = os.path.join(tmp_dir, basename)
+                        shutil.copy2(obj, dest)
+                        staged.append(dest)
+
+                    command = ["ar", "qc", libpdfium] + staged
+                    r.run(command)
+
+                    command = ["ranlib", libpdfium]
+                    r.run(command)
+                finally:
+                    shutil.rmtree(tmp_dir, ignore_errors=True)
 
             os.chdir(current_dir)
 

--- a/modules/lumin_markup_bs_rd_be.cpp.inc
+++ b/modules/lumin_markup_bs_rd_be.cpp.inc
@@ -1,0 +1,241 @@
+// Inserted into fpdfsdk/fpdf_annot.cpp by patch.py (Lumin: /BS, /RD, /BE for Square/Circle).
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace {
+
+bool LuminAnnotIsSquareOrCircle(FPDF_ANNOTATION annot) {
+  const FPDF_ANNOTATION_SUBTYPE st = FPDFAnnot_GetSubtype(annot);
+  return st == FPDF_ANNOT_SQUARE || st == FPDF_ANNOT_CIRCLE;
+}
+
+void LuminCopyAsciiz(const char* src, char* dst, int cap) {
+  if (!dst || cap < 1)
+    return;
+  if (!src) {
+    dst[0] = '\0';
+    return;
+  }
+  int i = 0;
+  for (; i < cap - 1 && src[i]; ++i)
+    dst[i] = src[i];
+  dst[i] = '\0';
+}
+
+int LuminParseDashCommaToArray(const char* dashComma, float* out, int maxOut) {
+  if (!out || maxOut < 1)
+    return 0;
+  if (!dashComma || !dashComma[0])
+    return 0;
+  int n = 0;
+  const char* p = dashComma;
+  while (*p && n < maxOut) {
+    while (*p == ' ' || *p == ',')
+      ++p;
+    if (!*p)
+      break;
+    char* endp = nullptr;
+    float v = std::strtof(p, &endp);
+    if (endp == p)
+      break;
+    out[n++] = v;
+    p = endp;
+  }
+  return n;
+}
+
+float LuminArrayGetFloat(const CPDF_Array* arr, size_t i) {
+  if (!arr || i >= arr->size())
+    return 0.0f;
+  RetainPtr<const CPDF_Object> o = arr->GetObjectAt(i);
+  return o && o->IsNumber() ? o->GetNumber() : 0.0f;
+}
+
+void LuminCopySNameToBuf(const CPDF_Object* sObj, char* outS, int sLen) {
+  if (!outS || sLen < 1)
+    return;
+  outS[0] = '\0';
+  if (!sObj)
+    return;
+  if (const CPDF_Name* nm = sObj->AsName()) {
+    LuminCopyAsciiz(nm->GetString().c_str(), outS, sLen);
+  }
+}
+
+}  // namespace
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_GetRectDiff(FPDF_ANNOTATION annot,
+                      float* outLeft,
+                      float* outTop,
+                      float* outRight,
+                      float* outBottom) {
+  if (!outLeft || !outTop || !outRight || !outBottom)
+    return false;
+  if (!LuminAnnotIsSquareOrCircle(annot))
+    return false;
+  const CPDF_Dictionary* annot_dict = GetAnnotDictFromFPDFAnnotation(annot);
+  if (!annot_dict)
+    return false;
+  RetainPtr<const CPDF_Array> rd = annot_dict->GetArrayFor("RD");
+  if (!rd || rd->size() < 4)
+    return false;
+  *outLeft = LuminArrayGetFloat(rd.Get(), 0);
+  *outTop = LuminArrayGetFloat(rd.Get(), 1);
+  *outRight = LuminArrayGetFloat(rd.Get(), 2);
+  *outBottom = LuminArrayGetFloat(rd.Get(), 3);
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetRectDiff(FPDF_ANNOTATION annot,
+                        float left,
+                        float top,
+                        float right,
+                        float bottom) {
+  if (!LuminAnnotIsSquareOrCircle(annot))
+    return false;
+  RetainPtr<CPDF_Dictionary> annot_dict =
+      GetMutableAnnotDictFromFPDFAnnotation(annot);
+  if (!annot_dict)
+    return false;
+  if (left == 0.0f && top == 0.0f && right == 0.0f && bottom == 0.0f) {
+    annot_dict->RemoveFor("RD");
+  } else {
+    RetainPtr<CPDF_Array> rd = annot_dict->GetOrCreateArrayFor("RD");
+    rd->Clear();
+    rd->AppendNew<CPDF_Number>(left);
+    rd->AppendNew<CPDF_Number>(top);
+    rd->AppendNew<CPDF_Number>(right);
+    rd->AppendNew<CPDF_Number>(bottom);
+  }
+  annot_dict->RemoveFor(pdfium::annotation::kAP);
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_GetBorderStyleDict(FPDF_ANNOTATION annot,
+                             char* outS,
+                             int sLen,
+                             char* outDashComma,
+                             int dashCommaLen,
+                             float* wOut) {
+  if (!wOut)
+    return false;
+  *wOut = 0.0f;
+  if (outS && sLen > 0)
+    outS[0] = '\0';
+  if (outDashComma && dashCommaLen > 0)
+    outDashComma[0] = '\0';
+  if (!LuminAnnotIsSquareOrCircle(annot))
+    return false;
+  const CPDF_Dictionary* annot_dict = GetAnnotDictFromFPDFAnnotation(annot);
+  if (!annot_dict)
+    return false;
+  RetainPtr<const CPDF_Dictionary> bs = annot_dict->GetDictFor("BS");
+  if (!bs)
+    return false;
+  RetainPtr<const CPDF_Object> sObjS = bs->GetObjectFor("S");
+  LuminCopySNameToBuf(sObjS ? sObjS.Get() : nullptr, outS, sLen);
+  RetainPtr<const CPDF_Array> d = bs->GetArrayFor("D");
+  if (d && d->size() > 0 && outDashComma && dashCommaLen > 0) {
+    std::string acc;
+    for (size_t i = 0; i < d->size(); ++i) {
+      if (i)
+        acc += ',';
+      char b[32];
+      std::snprintf(b, sizeof(b), "%g", static_cast<double>(LuminArrayGetFloat(d.Get(), i)));
+      acc += b;
+    }
+    LuminCopyAsciiz(acc.c_str(), outDashComma, dashCommaLen);
+  }
+  RetainPtr<const CPDF_Object> wobj = bs->GetObjectFor("W");
+  if (wobj && wobj->IsNumber())
+    *wOut = wobj->GetNumber();
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetBorderStyleDict(FPDF_ANNOTATION annot,
+                              const char* sName,
+                              const char* dashComma,
+                              float w) {
+  if (!LuminAnnotIsSquareOrCircle(annot))
+    return false;
+  RetainPtr<CPDF_Dictionary> annot_dict =
+      GetMutableAnnotDictFromFPDFAnnotation(annot);
+  if (!annot_dict)
+    return false;
+  if (!sName || !sName[0]) {
+    annot_dict->RemoveFor("BS");
+    annot_dict->RemoveFor(pdfium::annotation::kAP);
+    return true;
+  }
+  RetainPtr<CPDF_Dictionary> bs = annot_dict->GetOrCreateDictFor("BS");
+  bs->SetNewFor<CPDF_Name>("S", ByteString(sName));
+  float dtmp[32];
+  int dcount = LuminParseDashCommaToArray(dashComma, dtmp, 32);
+  if (dcount > 0 && sName[0] == 'D' && sName[1] == '\0') {
+    RetainPtr<CPDF_Array> darr = bs->GetOrCreateArrayFor("D");
+    darr->Clear();
+    for (int i = 0; i < dcount; ++i)
+      darr->AppendNew<CPDF_Number>(dtmp[i]);
+  } else {
+    bs->RemoveFor("D");
+  }
+  if (w > 0.0f)
+    bs->SetNewFor<CPDF_Number>("W", w);
+  else
+    bs->RemoveFor("W");
+  annot_dict->RemoveFor(pdfium::annotation::kAP);
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_GetBorderEffectDict(FPDF_ANNOTATION annot,
+                                char* outS,
+                                int sLen,
+                                float* iOut) {
+  if (!iOut)
+    return false;
+  *iOut = 0.0f;
+  if (outS && sLen > 0)
+    outS[0] = '\0';
+  if (!LuminAnnotIsSquareOrCircle(annot))
+    return false;
+  const CPDF_Dictionary* annot_dict = GetAnnotDictFromFPDFAnnotation(annot);
+  if (!annot_dict)
+    return false;
+  RetainPtr<const CPDF_Dictionary> be = annot_dict->GetDictFor("BE");
+  if (!be)
+    return false;
+  RetainPtr<const CPDF_Object> sObjE = be->GetObjectFor("S");
+  LuminCopySNameToBuf(sObjE ? sObjE.Get() : nullptr, outS, sLen);
+  RetainPtr<const CPDF_Object> iobj = be->GetObjectFor("I");
+  if (iobj && iobj->IsNumber())
+    *iOut = iobj->GetNumber();
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetBorderEffectDict(FPDF_ANNOTATION annot,
+                                const char* sName,
+                                float intensity) {
+  if (!LuminAnnotIsSquareOrCircle(annot))
+    return false;
+  RetainPtr<CPDF_Dictionary> annot_dict =
+      GetMutableAnnotDictFromFPDFAnnotation(annot);
+  if (!annot_dict)
+    return false;
+  if (!sName || !sName[0]) {
+    annot_dict->RemoveFor("BE");
+  } else {
+    RetainPtr<CPDF_Dictionary> be = annot_dict->GetOrCreateDictFor("BE");
+    be->SetNewFor<CPDF_Name>("S", ByteString(sName));
+    be->SetNewFor<CPDF_Number>("I", intensity);
+  }
+  annot_dict->RemoveFor(pdfium::annotation::kAP);
+  return true;
+}

--- a/modules/patch.py
+++ b/modules/patch.py
@@ -48,3 +48,1062 @@ def apply_public_headers(target):
         l.bullet("Applied: public headers (p2)", l.GREEN)
     else:
         l.bullet("Skipped: public headers (p2)", l.PURPLE)
+
+
+# -----------------------------------------------------------------------------
+def _apply_fpdf_annot_set_color_without_ca(target):
+    """Lumin: FPDFAnnot_SetColorWithoutCA in public/fpdf_annot.h and fpdfsdk/fpdf_annot.cpp."""
+    build_pdfium = os.path.join("build", target, "pdfium")
+    cpp = os.path.join(build_pdfium, "fpdfsdk", "fpdf_annot.cpp")
+    header = os.path.join(build_pdfium, "public", "fpdf_annot.h")
+    if not os.path.isfile(cpp) or not os.path.isfile(header):
+        l.bullet(
+            "Skipped: FPDFAnnot_SetColorWithoutCA (no PDFium tree for "
+            + target
+            + ")",
+            l.PURPLE,
+        )
+        return
+
+    h_old = """FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetColor(FPDF_ANNOTATION annot,
+                                                       FPDFANNOT_COLORTYPE type,
+                                                       unsigned int R,
+                                                       unsigned int G,
+                                                       unsigned int B,
+                                                       unsigned int A);
+
+// Experimental API.
+// Get the color of an annotation. If no color is specified, default to yellow"""
+
+    h_new = """FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetColor(FPDF_ANNOTATION annot,
+                                                       FPDFANNOT_COLORTYPE type,
+                                                       unsigned int R,
+                                                       unsigned int G,
+                                                       unsigned int B,
+                                                       unsigned int A);
+
+// Experimental API (Lumin).
+// Like FPDFAnnot_SetColor, but does not set annotation /CA. If A is 0, removes
+// the stroke color (/C) or interior color (/IC) (including when Normal /AP exists).
+// If A is greater than 0, sets the /C or /IC array to (R,G,B) like FPDFAnnot_SetColor
+// (including when Normal /AP is present) so the dictionary stays in sync; does
+// not set /CA.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetColorWithoutCA(
+    FPDF_ANNOTATION annot,
+    FPDFANNOT_COLORTYPE type,
+    unsigned int R,
+    unsigned int G,
+    unsigned int B,
+    unsigned int A);
+
+// Experimental API.
+// Get the color of an annotation. If no color is specified, default to yellow"""
+
+    h_new_legacy = """FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetColor(FPDF_ANNOTATION annot,
+                                                       FPDFANNOT_COLORTYPE type,
+                                                       unsigned int R,
+                                                       unsigned int G,
+                                                       unsigned int B,
+                                                       unsigned int A);
+
+// Experimental API (Lumin).
+// Like FPDFAnnot_SetColor, but does not set annotation /CA. If A is 0, removes
+// the stroke color (/C) or interior color (/IC) for |type|. If A is greater
+// than 0, does not modify the annotation dictionary.
+// Fails on annotations with their appearance streams already defined; for
+// those, use FPDFPageObj_Set{Stroke|Fill}Color() on the form objects instead.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetColorWithoutCA(
+    FPDF_ANNOTATION annot,
+    FPDFANNOT_COLORTYPE type,
+    unsigned int R,
+    unsigned int G,
+    unsigned int B,
+    unsigned int A);
+
+// Experimental API.
+// Get the color of an annotation. If no color is specified, default to yellow"""
+
+    cpp_old = """  pColor->AppendNew<CPDF_Number>(R / 255.f);
+  pColor->AppendNew<CPDF_Number>(G / 255.f);
+  pColor->AppendNew<CPDF_Number>(B / 255.f);
+
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetColor(FPDF_ANNOTATION annot,"""
+
+    cpp_set_color_without_ca = """
+// Like FPDFAnnot_SetColor, but does not set /CA. If A is 0, removes /C or /IC
+// and leaves /CA unchanged (removal works even when Normal /AP is present). If
+// A is greater than 0, always sets /C or /IC to (R,G,B) in the dict (unlike
+// FPDFAnnot_SetColor, this succeeds when Normal /AP is present) so the dict
+// matches the Lumin style layer; does not set /CA.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetColorWithoutCA(FPDF_ANNOTATION annot,
+                            FPDFANNOT_COLORTYPE type,
+                            unsigned int R,
+                            unsigned int G,
+                            unsigned int B,
+                            unsigned int A) {
+  RetainPtr<CPDF_Dictionary> pAnnotDict =
+      GetMutableAnnotDictFromFPDFAnnotation(annot);
+
+  if (!pAnnotDict || R > 255 || G > 255 || B > 255 || A > 255) {
+    return false;
+  }
+
+  ByteStringView key = type == FPDFANNOT_COLORTYPE_InteriorColor ? "IC" : "C";
+  if (A == 0) {
+    pAnnotDict->RemoveFor(key);
+    return true;
+  }
+
+  // A > 0: set /C or /IC the same as FPDFAnnot_SetColor, but do not set /CA.
+  RetainPtr<CPDF_Array> pColor = pAnnotDict->GetMutableArrayFor(key);
+  if (pColor) {
+    pColor->Clear();
+  } else {
+    pColor = pAnnotDict->SetNewFor<CPDF_Array>(ByteString(key));
+  }
+
+  pColor->AppendNew<CPDF_Number>(R / 255.f);
+  pColor->AppendNew<CPDF_Number>(G / 255.f);
+  pColor->AppendNew<CPDF_Number>(B / 255.f);
+
+  return true;
+}"""
+
+    cpp_new = (
+        """  pColor->AppendNew<CPDF_Number>(R / 255.f);
+  pColor->AppendNew<CPDF_Number>(G / 255.f);
+  pColor->AppendNew<CPDF_Number>(B / 255.f);
+
+  return true;
+}"""
+        + cpp_set_color_without_ca
+        + """
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetColor(FPDF_ANNOTATION annot,"""
+    )
+
+    # Legacy stub: A>0 was a no-op; HasAPStream could block A==0 removal.
+    upgrade_stub = """// Like FPDFAnnot_SetColor, but does not set /CA. If A is 0, removes /C or /IC
+// and leaves /CA unchanged. If A is greater than 0, does not change the
+// dictionary (no /C, /IC, or /CA updates).
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetColorWithoutCA(FPDF_ANNOTATION annot,
+                            FPDFANNOT_COLORTYPE type,
+                            unsigned int R,
+                            unsigned int G,
+                            unsigned int B,
+                            unsigned int A) {
+  RetainPtr<CPDF_Dictionary> pAnnotDict =
+      GetMutableAnnotDictFromFPDFAnnotation(annot);
+
+  if (!pAnnotDict || R > 255 || G > 255 || B > 255 || A > 255) {
+    return false;
+  }
+
+  if (HasAPStream(pAnnotDict.Get())) {
+    return false;
+  }
+
+  ByteStringView key = type == FPDFANNOT_COLORTYPE_InteriorColor ? "IC" : "C";
+  if (A == 0) {
+    pAnnotDict->RemoveFor(key);
+    return true;
+  }
+
+  // A > 0: do not set /C, /IC, or /CA.
+  return true;
+}"""
+
+    has_fn = f.file_has_content(cpp, "FPDFAnnot_SetColorWithoutCA")
+
+    # Transitional: was "fail with HasAPStream for A>0" (like stock SetColor) — Lumin
+    # now always updates /C|/IC when A>0 so the dict matches style/export even with /AP.
+    ap_block_remove = (
+        "  if (HasAPStream(pAnnotDict.Get())) {\n    return false;\n  }\n\n"
+        "  // A > 0: set /C or /IC the same as FPDFAnnot_SetColor, but do not set /CA."
+    )
+    if f.file_has_content(cpp, ap_block_remove):
+        f.replace_in_file(
+            cpp,
+            ap_block_remove,
+            "  // A > 0: set /C or /IC the same as FPDFAnnot_SetColor, but do not set /CA.",
+        )
+        c_old = (
+            "// Like FPDFAnnot_SetColor, but does not set /CA. If A is 0, removes /C or /IC\n"
+            "// and leaves /CA unchanged (removal works even when Normal /AP is present). If\n"
+            "// A is greater than 0, sets /C or /IC to (R,G,B) like SetColor, but does not\n"
+            "// set /CA; for A > 0, fails with HasAPStream, same as FPDFAnnot_SetColor."
+        )
+        c_new = (
+            "// Like FPDFAnnot_SetColor, but does not set /CA. If A is 0, removes /C or /IC\n"
+            "// and leaves /CA unchanged (removal works even when Normal /AP is present). If\n"
+            "// A is greater than 0, always sets /C or /IC to (R,G,B) like the SetColor dict\n"
+            "// path (unlike FPDFAnnot_SetColor, this succeeds when Normal /AP is present, so\n"
+            "// the dictionary stays in sync with the Lumin style layer and export)."
+        )
+        if f.file_has_content(cpp, c_old):
+            f.replace_in_file(cpp, c_old, c_new)
+        l.bullet("Upgraded: FPDFAnnot_SetColorWithoutCA (A>0 dict set with /AP present)", l.GREEN)
+        return
+
+    has_new = f.file_has_content(
+        cpp, "A > 0: set /C or /IC the same as FPDFAnnot_SetColor"
+    )
+    if has_new and not f.file_has_content(cpp, ap_block_remove):
+        l.bullet("Skipped: FPDFAnnot_SetColorWithoutCA (up to date)", l.PURPLE)
+        return
+    if f.file_has_content(cpp, "  // A > 0: do not set /C, /IC, or /CA."):
+        f.replace_in_file(cpp, upgrade_stub, cpp_set_color_without_ca)
+        f.replace_in_file(header, h_new_legacy, h_new)
+        l.bullet("Upgraded: FPDFAnnot_SetColorWithoutCA (A>0 sets /C|/IC, A==0+AP)", l.GREEN)
+        return
+    if not has_fn:
+        f.replace_in_file(header, h_old, h_new)
+        f.replace_in_file(cpp, cpp_old, cpp_new)
+        l.bullet("Applied: FPDFAnnot_SetColorWithoutCA (Lumin)", l.GREEN)
+        return
+    l.bullet("Skipped: FPDFAnnot_SetColorWithoutCA (non-legacy present; merge manually)", l.PURPLE)
+
+
+# -----------------------------------------------------------------------------
+def _apply_fpdf_annot_object_support_closeshapes(target):
+    """
+    Lumin: FPDFAnnot_AppendObject/UpdateObject on Square/Circle, not just Ink/Stamp.
+
+    Stock PDFium only allows FPDFAnnot_IsObjectSupportedSubtype for INK and STAMP; the same
+    GenerateEmptyAP + form path used for those works for closed shapes so we can rebuild custom
+    /AP (dashed, cloudy) in place without removing the annotation. Patches fpdfsdk/fpdf_annot.cpp and
+    the related comments in public/fpdf_annot.h.
+    """
+    build_pdfium = os.path.join("build", target, "pdfium")
+    cpp = os.path.join(build_pdfium, "fpdfsdk", "fpdf_annot.cpp")
+    header = os.path.join(build_pdfium, "public", "fpdf_annot.h")
+    if not os.path.isfile(cpp) or not os.path.isfile(header):
+        l.bullet(
+            "Skipped: FPDFAnnot closed-shape object support (no PDFium tree for " + target + ")",
+            l.PURPLE,
+        )
+        return
+    if f.file_has_content(cpp, "FPDF_ANNOT_SQUARE || subtype == FPDF_ANNOT_CIRCLE"):
+        l.bullet("Skipped: FPDFAnnot closed-shape object support (present)", l.PURPLE)
+        return
+
+    cpp_old = """FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_IsObjectSupportedSubtype(FPDF_ANNOTATION_SUBTYPE subtype) {
+  // The supported subtypes must also be communicated in the user doc.
+  return subtype == FPDF_ANNOT_INK || subtype == FPDF_ANNOT_STAMP;
+}"""
+
+    cpp_new = """FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_IsObjectSupportedSubtype(FPDF_ANNOTATION_SUBTYPE subtype) {
+  // Lumin: Square/Circle can host form-object appearance streams (dashed, cloudy) like Ink.
+  // The supported subtypes must also be communicated in the user doc.
+  return subtype == FPDF_ANNOT_INK || subtype == FPDF_ANNOT_STAMP ||
+         subtype == FPDF_ANNOT_SQUARE || subtype == FPDF_ANNOT_CIRCLE;
+}"""
+
+    h_old1 = """// Check if an annotation subtype is currently supported for object extraction,
+// update, and removal.
+// Currently supported subtypes: ink and stamp.
+//
+//   subtype   - the subtype to be checked.
+//
+// Returns true if this subtype supported.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_IsObjectSupportedSubtype(FPDF_ANNOTATION_SUBTYPE subtype);"""
+
+    h_new1 = """// Check if an annotation subtype is currently supported for object extraction,
+// update, and removal.
+// Lumin: also square and circle (custom /AP from path objects). Stock: ink and stamp.
+//
+//   subtype   - the subtype to be checked.
+//
+// Returns true if this subtype supported.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_IsObjectSupportedSubtype(FPDF_ANNOTATION_SUBTYPE subtype);"""
+
+    f.replace_in_file(cpp, cpp_old, cpp_new)
+    f.replace_in_file(header, h_old1, h_new1)
+    h_append_old = (
+        "//   will be owned by |annot|. Note that an |obj| cannot belong to more than one\n"
+        "//   |annot|. Currently, only ink and stamp annotations are supported by this API.\n"
+    )
+    h_append_new = (
+        "//   will be owned by |annot|. Note that an |obj| cannot belong to more than one\n"
+        "//   |annot|. (Lumin: square and circle; stock: ink and stamp.) "
+    )
+    if f.file_has_content(header, h_append_old):
+        f.replace_in_file(header, h_append_old, h_append_new)
+    h_update_old = (
+        "//   been retrieved by FPDFAnnot_GetObject(). Currently, only ink and stamp\n"
+        "// annotations are supported by this API. Also note that only path, image, and\n"
+    )
+    h_update_new = (
+        "//   been retrieved by FPDFAnnot_GetObject(). Lumin: also square and circle. "
+        "Stock: ink and stamp. Also\n// note that only path, image, and\n"
+    )
+    if f.file_has_content(header, h_update_old):
+        f.replace_in_file(header, h_update_old, h_update_new)
+    l.bullet("Applied: FPDFAnnot closed-shape object support (Lumin)", l.GREEN)
+
+
+# -----------------------------------------------------------------------------
+def _apply_fpdf_annot_line_native_create_and_setline(target):
+    """
+    Lumin: (1) allow FPDFPage_CreateAnnot(FPDF_ANNOT_LINE) by extending
+    FPDFAnnot_IsSupportedSubtype; (2) add FPDFAnnot_SetLine to write /L (GetLine
+    is read-only in stock PDFium); (3) allow form-object /AP for Line like Square,
+    by extending FPDFAnnot_IsObjectSupportedSubtype.
+
+    Stock PDFium can *read* Line (FPDFAnnot_GetLine) but not create; LineAnnotation_import
+    uses native /Line, not an Ink carrier. Rebuild the xcframework / jni after applying.
+    """
+    build_pdfium = os.path.join("build", target, "pdfium")
+    cpp = os.path.join(build_pdfium, "fpdfsdk", "fpdf_annot.cpp")
+    header = os.path.join(build_pdfium, "public", "fpdf_annot.h")
+    if not os.path.isfile(cpp) or not os.path.isfile(header):
+        l.bullet(
+            "Skipped: FPDF line create + SetLine (no PDFium tree for " + target + ")",
+            l.PURPLE,
+        )
+        return
+
+    # Idempotent: each sub-step is skipped if already present (no single early
+    # return on SetLine, so a partial apply can be completed on a later run).
+    h_supported_old = (
+        "//    - ink\n"
+        "//    - link\n"
+    )
+    h_supported_new = (
+        "//    - ink\n"
+        "//    - line (Lumin: FPDFPage_CreateAnnot; requires patch.py)\n"
+        "//    - link\n"
+    )
+    if f.file_has_content(header, h_supported_old) and not f.file_has_content(
+        header, "line (Lumin: FPDFPage_CreateAnnot"
+    ):
+        f.replace_in_file(header, h_supported_old, h_supported_new)
+        l.bullet("Applied: fpdf_annot.h IsSupported list (line)", l.GREEN)
+
+    # Match stock PDFium switch order: INK, LINK (see fpdfsdk/fpdf_annot.cpp).
+    cpp_isup_old = (
+        "    case FPDF_ANNOT_INK:\n"
+        "    case FPDF_ANNOT_LINK:\n"
+    )
+    cpp_isup_new = (
+        "    case FPDF_ANNOT_INK:\n"
+        "    case FPDF_ANNOT_LINE:\n"
+        "    case FPDF_ANNOT_LINK:\n"
+    )
+    if f.file_has_content(cpp, cpp_isup_new):
+        pass  # already patched
+    elif f.file_has_content(cpp, cpp_isup_old):
+        f.replace_in_file(cpp, cpp_isup_old, cpp_isup_new)
+        l.bullet("Applied: FPDFAnnot_IsSupportedSubtype(FPDF_ANNOT_LINE)", l.GREEN)
+
+    cpp_iobj_old = (
+        "  return subtype == FPDF_ANNOT_INK || subtype == FPDF_ANNOT_STAMP ||\n"
+        "         subtype == FPDF_ANNOT_SQUARE || subtype == FPDF_ANNOT_CIRCLE;\n"
+    )
+    cpp_iobj_new = (
+        "  return subtype == FPDF_ANNOT_INK || subtype == FPDF_ANNOT_STAMP ||\n"
+        "         subtype == FPDF_ANNOT_SQUARE || subtype == FPDF_ANNOT_CIRCLE ||\n"
+        "         subtype == FPDF_ANNOT_LINE;\n"
+    )
+    if f.file_has_content(cpp, "subtype == FPDF_ANNOT_LINE"):
+        pass
+    elif f.file_has_content(cpp, cpp_iobj_old):
+        f.replace_in_file(cpp, cpp_iobj_old, cpp_iobj_new)
+        h_iobj = (
+            "// Lumin: also square and circle (custom /AP from path objects). Stock: ink and stamp."
+        )
+        h_iobj2 = (
+            "// Lumin: also square, circle, and line (custom /AP from path objects). "
+            "Stock: ink and stamp."
+        )
+        if f.file_has_content(header, h_iobj):
+            f.replace_in_file(header, h_iobj, h_iobj2)
+        l.bullet("Applied: FPDFAnnot_IsObjectSupportedSubtype(FPDF_ANNOT_LINE)", l.GREEN)
+    else:
+        l.bullet("Skipped: IsObjectSupported LINE (pattern not found; manual merge?)", l.PURPLE)
+
+    getline_block_old = (
+        "  end->x = line->GetFloatAt(2);\n"
+        "  end->y = line->GetFloatAt(3);\n"
+        "  return true;\n"
+        "}\n"
+        "\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetBorder(FPDF_ANNOTATION annot,\n"
+    )
+    setline_impl = (
+        "  end->x = line->GetFloatAt(2);\n"
+        "  end->y = line->GetFloatAt(3);\n"
+        "  return true;\n"
+        "}\n"
+        "\n"
+        "// Experimental API (Lumin). Sets the /L array (two points) for a Line\n"
+        "// annotation. Clears the Normal /AP so viewers regenerate from the dict. Must\n"
+        "// be FPDF_ANNOT_LINE.\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetLine(FPDF_ANNOTATION annot,\n"
+        "                                                        const FS_POINTF* start,\n"
+        "                                                        const FS_POINTF* end) {\n"
+        "  if (!start || !end) {\n"
+        "    return false;\n"
+        "  }\n"
+        "  if (FPDFAnnot_GetSubtype(annot) != FPDF_ANNOT_LINE) {\n"
+        "    return false;\n"
+        "  }\n"
+        "  RetainPtr<CPDF_Dictionary> annot_dict =\n"
+        "      GetMutableAnnotDictFromFPDFAnnotation(annot);\n"
+        "  if (!annot_dict) {\n"
+        "    return false;\n"
+        "  }\n"
+        "  RetainPtr<CPDF_Array> line = annot_dict->SetNewFor<CPDF_Array>(\n"
+        "      pdfium::annotation::kL);\n"
+        "  if (!line) {\n"
+        "    return false;\n"
+        "  }\n"
+        "  line->Clear();\n"
+        "  line->AppendNew<CPDF_Number>(start->x);\n"
+        "  line->AppendNew<CPDF_Number>(start->y);\n"
+        "  line->AppendNew<CPDF_Number>(end->x);\n"
+        "  line->AppendNew<CPDF_Number>(end->y);\n"
+        "  annot_dict->RemoveFor(pdfium::annotation::kAP);\n"
+        "  return true;\n"
+        "}\n"
+        "\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetBorder(FPDF_ANNOTATION annot,\n"
+    )
+    if f.file_has_content(cpp, "FPDFAnnot_SetLine("):
+        if not f.file_has_content(header, "FPDFAnnot_SetLine("):
+            h_get_old = (
+                "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetLine(FPDF_ANNOTATION annot,\n"
+                "                                                      FS_POINTF* start,\n"
+                "                                                      FS_POINTF* end);\n"
+            )
+            h_get_new = (
+                "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetLine(FPDF_ANNOTATION annot,\n"
+                "                                                      FS_POINTF* start,\n"
+                "                                                      FS_POINTF* end);\n"
+                "\n"
+                "// Experimental API (Lumin). Set /L for a Line annotation (see patch.py).\n"
+                "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetLine(FPDF_ANNOTATION annot,\n"
+                "                                                    const FS_POINTF* start,\n"
+                "                                                    const FS_POINTF* end);\n"
+            )
+            if f.file_has_content(header, h_get_old):
+                f.replace_in_file(header, h_get_old, h_get_new)
+                l.bullet("Applied: FPDFAnnot_SetLine declaration in public header (catch-up)", l.GREEN)
+    elif f.file_has_content(cpp, getline_block_old):
+        f.replace_in_file(cpp, getline_block_old, setline_impl)
+        h_get_old = (
+            "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetLine(FPDF_ANNOTATION annot,\n"
+            "                                                      FS_POINTF* start,\n"
+            "                                                      FS_POINTF* end);\n"
+        )
+        h_get_new = (
+            "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetLine(FPDF_ANNOTATION annot,\n"
+            "                                                      FS_POINTF* start,\n"
+            "                                                      FS_POINTF* end);\n"
+            "\n"
+            "// Experimental API (Lumin). Set /L for a Line annotation (see patch.py).\n"
+            "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetLine(FPDF_ANNOTATION annot,\n"
+            "                                                    const FS_POINTF* start,\n"
+            "                                                    const FS_POINTF* end);\n"
+        )
+        if f.file_has_content(header, h_get_old) and not f.file_has_content(
+            header, "FPDFAnnot_SetLine("
+        ):
+            f.replace_in_file(header, h_get_old, h_get_new)
+        l.bullet("Applied: FPDFAnnot_SetLine in fpdfsdk", l.GREEN)
+    else:
+        l.bullet("Skipped: FPDFAnnot_SetLine insert (GetLine/SetBorder boundary not found)", l.PURPLE)
+
+
+# -----------------------------------------------------------------------------
+def _apply_fpdf_annot_set_number_value(target):
+    """
+    Lumin: FPDFAnnot_SetNumberValue in public/fpdf_annot.h and
+    fpdfsdk/fpdf_annot.cpp (e.g. /CA opacity, PDF Object Number).
+    """
+    build_pdfium = os.path.join("build", target, "pdfium")
+    cpp = os.path.join(build_pdfium, "fpdfsdk", "fpdf_annot.cpp")
+    header = os.path.join(build_pdfium, "public", "fpdf_annot.h")
+    if not os.path.isfile(cpp) or not os.path.isfile(header):
+        l.bullet(
+            "Skipped: FPDFAnnot_SetNumberValue (no PDFium tree for " + target + ")",
+            l.PURPLE,
+        )
+        return
+    if f.file_has_content(cpp, "FPDFAnnot_SetNumberValue("):
+        l.bullet("Skipped: FPDFAnnot_SetNumberValue (already present)", l.PURPLE)
+        return
+
+    h_old = """FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_GetNumberValue(FPDF_ANNOTATION annot,
+                         FPDF_BYTESTRING key,
+                         float* value);
+
+// Experimental API.
+// Set the AP (appearance string) in |annot|'s dictionary for a given
+// |appearanceMode|."""
+    h_new = """FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_GetNumberValue(FPDF_ANNOTATION annot,
+                         FPDF_BYTESTRING key,
+                         float* value);
+
+// Experimental API.
+// Set the number value for |key| in |annot|'s dictionary (replaces an existing
+// value if present). The value is stored as FPDF_OBJECT_NUMBER.
+// Common keys: "CA" (constant alpha / opacity, 0.0–1.0).
+// Returns true on success.
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetNumberValue(FPDF_ANNOTATION annot,
+                         FPDF_BYTESTRING key,
+                         float value);
+
+// Experimental API.
+// Set the AP (appearance string) in |annot|'s dictionary for a given
+// |appearanceMode|."""
+
+    cpp_old = """  *value = p->GetNumber();
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetAP(FPDF_ANNOTATION annot,
+                FPDF_ANNOT_APPEARANCEMODE appearanceMode,
+                FPDF_WIDESTRING value) {"""
+    cpp_new = """  *value = p->GetNumber();
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetNumberValue(FPDF_ANNOTATION annot,
+                         FPDF_BYTESTRING key,
+                         float value) {
+  RetainPtr<CPDF_Dictionary> pAnnotDict =
+      GetMutableAnnotDictFromFPDFAnnotation(annot);
+  if (!pAnnotDict) {
+    return false;
+  }
+
+  pAnnotDict->SetNewFor<CPDF_Number>(key, value);
+  return true;
+}
+
+FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV
+FPDFAnnot_SetAP(FPDF_ANNOTATION annot,
+                FPDF_ANNOT_APPEARANCEMODE appearanceMode,
+                FPDF_WIDESTRING value) {"""
+
+    if f.file_has_content(header, h_old) and f.file_has_content(cpp, cpp_old):
+        f.replace_in_file(header, h_old, h_new)
+        f.replace_in_file(cpp, cpp_old, cpp_new)
+        l.bullet("Applied: FPDFAnnot_SetNumberValue in fpdfsdk", l.GREEN)
+    else:
+        l.bullet(
+            "Skipped: FPDFAnnot_SetNumberValue (pattern not found; manual merge?)",
+            l.PURPLE,
+        )
+
+
+# -----------------------------------------------------------------------------
+def _apply_fpdf_annot_line_endings(target):
+    """
+    Lumin: FPDFAnnot_GetLineEndings / FPDFAnnot_SetLineEndings for ISO /LE (two
+    name entries) on Line / Polyline annotations. See LineAnnotation.cpp.
+    """
+    build_pdfium = os.path.join("build", target, "pdfium")
+    cpp = os.path.join(build_pdfium, "fpdfsdk", "fpdf_annot.cpp")
+    header = os.path.join(build_pdfium, "public", "fpdf_annot.h")
+    if not os.path.isfile(cpp) or not os.path.isfile(header):
+        l.bullet(
+            "Skipped: FPDF line /LE (no PDFium tree for " + target + ")",
+            l.PURPLE,
+        )
+        return
+    if f.file_has_content(cpp, "FPDFAnnot_GetLineEndings("):
+        l.bullet("Skipped: FPDF line /LE (already present)", l.PURPLE)
+        return
+    if not f.file_has_content(cpp, "FPDFAnnot_SetLine("):
+        l.bullet(
+            "Skipped: FPDF line /LE (FPDFAnnot_SetLine missing; apply line patch first)",
+            l.PURPLE,
+        )
+        return
+
+    cpp_insert_before_setborder = (
+        "  annot_dict->RemoveFor(pdfium::annotation::kAP);\n"
+        "  return true;\n"
+        "}\n"
+        "\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetBorder"
+    )
+    if not f.file_has_content(cpp, cpp_insert_before_setborder):
+        l.bullet(
+            "Skipped: FPDF line /LE (SetLine block before SetBorder not found)",
+            l.PURPLE,
+        )
+        return
+
+    le_impl = (
+        "  annot_dict->RemoveFor(pdfium::annotation::kAP);\n"
+        "  return true;\n"
+        "}\n"
+        "\n"
+        "namespace {\n"
+        "void LuminCopyByteStringToUserBuf(const ByteString& bs, char* out, int n) "
+        "{\n"
+        "  if (!out || n < 1) {\n"
+        "    return;\n"
+        "  }\n"
+        "  const char* s = bs.c_str() ? bs.c_str() : \"\";\n"
+        "  int cap = n - 1;\n"
+        "  int i = 0;\n"
+        "  for (; i < cap && s[i]; ++i) {\n"
+        "    out[i] = s[i];\n"
+        "  }\n"
+        "  out[i] = '\\0';\n"
+        "}\n"
+        "ByteString LuminNameTokenOrNone(const char* s) {\n"
+        "  if (!s || s[0] == '\\0') {\n"
+        "    return ByteString(\"None\");\n"
+        "  }\n"
+        "  return ByteString(s);\n"
+        "}\n"
+        "}  // namespace\n"
+        "\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetLineEndings("
+        "    FPDF_ANNOTATION annot, char* outStart, int outStartLen, char* outEnd, int outEndLen) "
+        "{\n"
+        "  if (!outStart || outStartLen < 1 || !outEnd || outEndLen < 1) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  const FPDF_ANNOTATION_SUBTYPE st = FPDFAnnot_GetSubtype(annot);\n"
+        "  if (st != FPDF_ANNOT_LINE && st != FPDF_ANNOT_POLYLINE) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  const CPDF_Dictionary* annot_dict = GetAnnotDictFromFPDFAnnotation(annot);\n"
+        "  if (!annot_dict) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  RetainPtr<const CPDF_Array> le = annot_dict->GetArrayFor(\"LE\");\n"
+        "  if (!le || le->size() < 2) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  RetainPtr<const CPDF_Object> o0 = le->GetObjectAt(0);\n"
+        "  RetainPtr<const CPDF_Object> o1 = le->GetObjectAt(1);\n"
+        "  if (!o0 || !o1) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  const CPDF_Name* n0 = ToName(o0.Get());\n"
+        "  const CPDF_Name* n1 = ToName(o1.Get());\n"
+        "  if (!n0 || !n1) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  LuminCopyByteStringToUserBuf(n0->GetString(), outStart, outStartLen);\n"
+        "  LuminCopyByteStringToUserBuf(n1->GetString(), outEnd, outEndLen);\n"
+        "  return true;\n"
+        "}\n"
+        "\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetLineEndings("
+        "    FPDF_ANNOTATION annot, const char* startName, const char* endName) "
+        "{\n"
+        "  const FPDF_ANNOTATION_SUBTYPE st = FPDFAnnot_GetSubtype(annot);\n"
+        "  if (st != FPDF_ANNOT_LINE && st != FPDF_ANNOT_POLYLINE) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  RetainPtr<CPDF_Dictionary> annot_dict =\n"
+        "      GetMutableAnnotDictFromFPDFAnnotation(annot);\n"
+        "  if (!annot_dict) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  RetainPtr<CPDF_Array> le = annot_dict->SetNewFor<CPDF_Array>(\"LE\");\n"
+        "  if (!le) "
+        "{\n"
+        "    return false;\n"
+        "  }\n"
+        "  le->Clear();\n"
+        "  le->AppendNew<CPDF_Name>(LuminNameTokenOrNone(startName));\n"
+        "  le->AppendNew<CPDF_Name>(LuminNameTokenOrNone(endName));\n"
+        "  annot_dict->RemoveFor(pdfium::annotation::kAP);\n"
+        "  return true;\n"
+        "}\n"
+        "\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetBorder"
+    )
+    f.replace_in_file(cpp, cpp_insert_before_setborder, le_impl)
+
+    h_setline = (
+        "// Experimental API (Lumin). Set /L for a Line annotation (see patch.py).\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetLine(FPDF_ANNOTATION annot,\n"
+        "                                                    const FS_POINTF* start,\n"
+        "                                                    const FS_POINTF* end);"
+    )
+    h_setline_le = (
+        h_setline
+        + "\n"
+        + "\n"
+        + "// Experimental API (Lumin). Read or set /LE (line endings) for"
+        " Line; see patch.py.\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetLineEndings("
+        "    FPDF_ANNOTATION annot, char* outStart, int outStartLen, char* outEnd,\n"
+        "    int outEndLen);\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_SetLineEndings("
+        "    FPDF_ANNOTATION annot, const char* startName, const char* endName);"
+    )
+    if f.file_has_content(header, h_setline) and not f.file_has_content(
+        header, "FPDFAnnot_GetLineEndings("
+    ):
+        f.replace_in_file(header, h_setline, h_setline_le)
+    l.bullet("Applied: FPDFAnnot Get/SetLineEndings in fpdfsdk", l.GREEN)
+    _apply_fpdf_annot_line_endings_polyline_upgrade(target)
+
+
+# -----------------------------------------------------------------------------
+def _apply_fpdf_annot_line_endings_polyline_upgrade(target):
+    """
+    Idempotent: extend existing Get/SetLineEndings (LINE-only) to LINE+POLYLINE
+    on set. For PDFium trees patched before polyline support was added to
+    le_impl.
+    """
+    build_pdfium = os.path.join("build", target, "pdfium")
+    cpp = os.path.join(build_pdfium, "fpdfsdk", "fpdf_annot.cpp")
+    if not os.path.isfile(cpp) or not f.file_has_content(cpp, "FPDFAnnot_GetLineEndings("):
+        return
+    if f.file_has_content(cpp, "st != FPDF_ANNOT_LINE && st != FPDF_ANNOT_POLYLINE"):
+        l.bullet("Skipped: line /LE polyline upgrade (already present)", l.PURPLE)
+        return
+
+    g_old = (
+        "  if (FPDFAnnot_GetSubtype(annot) != FPDF_ANNOT_LINE) \n"
+        "  {\n"
+        "    return false;\n"
+        "  }\n"
+        "  const CPDF_Dictionary* annot_dict = GetAnnotDictFromFPDFAnnotation(annot);\n"
+    )
+    g_new = (
+        "  const FPDF_ANNOTATION_SUBTYPE st = FPDFAnnot_GetSubtype(annot);\n"
+        "  if (st != FPDF_ANNOT_LINE && st != FPDF_ANNOT_POLYLINE) \n"
+        "  {\n"
+        "    return false;\n"
+        "  }\n"
+        "  const CPDF_Dictionary* annot_dict = GetAnnotDictFromFPDFAnnotation(annot);\n"
+    )
+    s_old = (
+        "  if (FPDFAnnot_GetSubtype(annot) != FPDF_ANNOT_LINE) \n"
+        "  {\n"
+        "    return false;\n"
+        "  }\n"
+        "  RetainPtr<CPDF_Dictionary> annot_dict =\n"
+        "      GetMutableAnnotDictFromFPDFAnnotation(annot);\n"
+    )
+    s_new = (
+        "  const FPDF_ANNOTATION_SUBTYPE st = FPDFAnnot_GetSubtype(annot);\n"
+        "  if (st != FPDF_ANNOT_LINE && st != FPDF_ANNOT_POLYLINE) \n"
+        "  {\n"
+        "    return false;\n"
+        "  }\n"
+        "  RetainPtr<CPDF_Dictionary> annot_dict =\n"
+        "      GetMutableAnnotDictFromFPDFAnnotation(annot);\n"
+    )
+    plle_old = (
+        "  annot_dict->RemoveFor(\"LMLE1\");\n"
+        "  annot_dict->RemoveFor(pdfium::annotation::kAP);\n"
+    )
+    plle_new = "  annot_dict->RemoveFor(pdfium::annotation::kAP);\n"
+    if f.file_has_content(cpp, g_old):
+        f.replace_in_file(cpp, g_old, g_new)
+        l.bullet("Upgraded: GetLineEndings allows polyline", l.GREEN)
+    if f.file_has_content(cpp, s_old):
+        f.replace_in_file(cpp, s_old, s_new)
+        l.bullet("Upgraded: SetLineEndings allows polyline", l.GREEN)
+    if f.file_has_content(cpp, plle_old):
+        f.replace_in_file(cpp, plle_old, plle_new)
+        l.bullet("Upgraded: SetLineEndings drops legacy LMLE1 removal", l.GREEN)
+
+
+# -----------------------------------------------------------------------------
+def _apply_fpdf_annot_interior_color_key_exists(target):
+    """Lumin: /C and /IC key-exists helpers in public/fpdf_annot.h and fpdfsdk/fpdf_annot.cpp."""
+    build_pdfium = os.path.join("build", target, "pdfium")
+    cpp = os.path.join(build_pdfium, "fpdfsdk", "fpdf_annot.cpp")
+    header = os.path.join(build_pdfium, "public", "fpdf_annot.h")
+    if not os.path.isfile(cpp):
+        l.bullet(
+            "Skipped: FPDFAnnot_AnnotationColorDictionaryKeyExists (no fpdfsdk for "
+            + target
+            + ")",
+            l.PURPLE,
+        )
+        return
+
+    insert_cpp = (
+        "\n// Lumin: true if the annotation dict has a color array for |type| (/C or /IC).\n"
+        "// FPDFAnnot_GetColor returns a default (black, or highlight yellow) when the key\n"
+        "// is absent, which must not be treated as an authored color for XFDF export.\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_AnnotationColorDictionaryKeyExists(\n"
+        "    FPDF_ANNOTATION annot,\n"
+        "    FPDFANNOT_COLORTYPE type) {\n"
+        "  RetainPtr<CPDF_Dictionary> pAnnotDict =\n"
+        "      GetMutableAnnotDictFromFPDFAnnotation(annot);\n"
+        "  if (!pAnnotDict) {\n"
+        "    return false;\n"
+        "  }\n"
+        "  return pAnnotDict->KeyExist(\n"
+        "      type == FPDFANNOT_COLORTYPE_InteriorColor ? \"IC\" : \"C\");\n"
+        "}\n\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_StrokeColorDictionaryKeyExists(FPDF_ANNOTATION annot) {\n"
+        "  return FPDFAnnot_AnnotationColorDictionaryKeyExists(\n"
+        "      annot, FPDFANNOT_COLORTYPE_Color);\n"
+        "}\n\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_InteriorColorDictionaryKeyExists(FPDF_ANNOTATION annot) {\n"
+        "  return FPDFAnnot_AnnotationColorDictionaryKeyExists(\n"
+        "      annot, FPDFANNOT_COLORTYPE_InteriorColor);\n"
+        "}\n"
+    )
+    if not f.file_has_content(cpp, "FPDFAnnot_AnnotationColorDictionaryKeyExists"):
+        ic_only_old = (
+            "// Lumin: true if the annotation dictionary has an /IC (interior color) entry.\n"
+            "// FPDFAnnot_GetColor(Interior) returns a default black when /IC is absent, which\n"
+            "// must not be treated as an authored fill for XFDF export.\n"
+            "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+            "FPDFAnnot_InteriorColorDictionaryKeyExists(FPDF_ANNOTATION annot) {\n"
+            "  RetainPtr<CPDF_Dictionary> pAnnotDict =\n"
+            "      GetMutableAnnotDictFromFPDFAnnotation(annot);\n"
+            "  if (!pAnnotDict) {\n"
+            "    return false;\n"
+            "  }\n"
+            "  return pAnnotDict->KeyExist(\"IC\");\n"
+            "}\n"
+        )
+        if f.file_has_content(cpp, ic_only_old):
+            f.replace_in_file(cpp, ic_only_old, insert_cpp.lstrip())
+            l.bullet("Upgraded: IC-only key check → /C and /IC (Lumin C++)", l.GREEN)
+        else:
+            anchor_old = (
+                "  return true;\n"
+                "}\n\n"
+                "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+                "FPDFAnnot_HasAttachmentPoints(FPDF_ANNOTATION annot) {"
+            )
+            if f.file_has_content(cpp, anchor_old):
+                f.replace_in_file(
+                    cpp,
+                    anchor_old,
+                    "  return true;\n}\n" + insert_cpp + "\n"
+                    "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+                    "FPDFAnnot_HasAttachmentPoints(FPDF_ANNOTATION annot) {",
+                )
+                l.bullet("Applied: FPDFAnnot /C and /IC key exists (Lumin C++)", l.GREEN)
+            else:
+                l.bullet(
+                    "Skipped: FPDFAnnot color dict in cpp (no anchor; merge manually)",
+                    l.PURPLE,
+                )
+    else:
+        l.bullet(
+            "Skipped: FPDFAnnot color dict key exists in fpdfsdk (cpp up to date)",
+            l.PURPLE,
+        )
+
+    h_old_min = (
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetColor(FPDF_ANNOTATION annot,\n"
+        "                                                       FPDFANNOT_COLORTYPE type,\n"
+        "                                                       unsigned int* R,\n"
+        "                                                       unsigned int* G,\n"
+        "                                                       unsigned int* B,\n"
+        "                                                       unsigned int* A);\n\n"
+        "// Experimental API.\n"
+        "// Check if the annotation is of a type that has attachment points"
+    )
+    h_new_block = (
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetColor(FPDF_ANNOTATION annot,\n"
+        "                                                       FPDFANNOT_COLORTYPE type,\n"
+        "                                                       unsigned int* R,\n"
+        "                                                       unsigned int* G,\n"
+        "                                                       unsigned int* B,\n"
+        "                                                       unsigned int* A);\n\n"
+        "// Experimental API (Lumin).\n"
+        "// True if the annotation dict has /C or /IC for |type|.\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_AnnotationColorDictionaryKeyExists(\n"
+        "    FPDF_ANNOTATION annot,\n"
+        "    FPDFANNOT_COLORTYPE type);\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_StrokeColorDictionaryKeyExists(FPDF_ANNOTATION annot);\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_InteriorColorDictionaryKeyExists(FPDF_ANNOTATION annot);\n\n"
+        "// Experimental API.\n"
+        "// Check if the annotation is of a type that has attachment points"
+    )
+    h_old_ic = (
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV FPDFAnnot_GetColor(FPDF_ANNOTATION annot,\n"
+        "                                                       FPDFANNOT_COLORTYPE type,\n"
+        "                                                       unsigned int* R,\n"
+        "                                                       unsigned int* G,\n"
+        "                                                       unsigned int* B,\n"
+        "                                                       unsigned int* A);\n\n"
+        "// Experimental API (Lumin).\n"
+        "// Returns true if the annotation dictionary has an /IC (interior color) entry.\n"
+        "// FPDFAnnot_GetColor(Interior) synthesizes a default when /IC is missing; this\n"
+        "// predicate distinguishes absent /IC from a real color array for export.\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_InteriorColorDictionaryKeyExists(FPDF_ANNOTATION annot);\n\n"
+        "// Experimental API.\n"
+        "// Check if the annotation is of a type that has attachment points"
+    )
+    if os.path.isfile(header) and not f.file_has_content(
+        header, "FPDFAnnot_AnnotationColorDictionaryKeyExists"
+    ):
+        if f.file_has_content(header, h_old_ic):
+            f.replace_in_file(header, h_old_ic, h_new_block)
+            l.bullet("Upgraded: FPDFAnnot color key headers (Lumin public header)", l.GREEN)
+        elif f.file_has_content(header, h_old_min):
+            f.replace_in_file(header, h_old_min, h_new_block)
+            l.bullet("Applied: FPDFAnnot color key headers (Lumin public header)", l.GREEN)
+        else:
+            l.bullet(
+                "Skipped: FPDFAnnot color key exists (header anchor mismatch; merge manually)",
+                l.PURPLE,
+            )
+
+
+# -----------------------------------------------------------------------------
+def _apply_fpdf_annot_markup_bs_rd_be(target):
+    """
+    Lumin: FPDFAnnot_Get/Set for ISO /BS, /RD, /BE on Square and Circle annotations
+    (see SquareAnnotation.cpp / patch lumin_markup_bs_rd_be.cpp.inc).
+    Requires FPDFAnnot_SetNumberValue (Lumin) already applied so we can anchor
+    after its closing brace and before FPDFAnnot_SetAP.
+    """
+    build_pdfium = os.path.join("build", target, "pdfium")
+    cpp = os.path.join(build_pdfium, "fpdfsdk", "fpdf_annot.cpp")
+    header = os.path.join(build_pdfium, "public", "fpdf_annot.h")
+    if not os.path.isfile(cpp) or not os.path.isfile(header):
+        l.bullet(
+            "Skipped: FPDF BS/RD/BE (no PDFium tree for " + target + ")",
+            l.PURPLE,
+        )
+        return
+    if f.file_has_content(cpp, "FPDFAnnot_GetRectDiff("):
+        l.bullet("Skipped: FPDF BS/RD/BE (already present)", l.PURPLE)
+        return
+    if not f.file_has_content(cpp, "FPDFAnnot_SetNumberValue("):
+        l.bullet(
+            "Skipped: FPDF BS/RD/BE (SetNumberValue missing; run set-number patch first)",
+            l.PURPLE,
+        )
+        return
+
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    inc_path = os.path.join(this_dir, "lumin_markup_bs_rd_be.cpp.inc")
+    if not os.path.isfile(inc_path):
+        l.bullet("Skipped: FPDF BS/RD/BE (lumin_markup_bs_rd_be.cpp.inc not found)", l.PURPLE)
+        return
+    with open(inc_path, "r", encoding="utf-8") as inc_file:
+        markup_impl = inc_file.read()
+
+    cpp_old = (
+        "  pAnnotDict->SetNewFor<CPDF_Number>(key, value);\n"
+        "  return true;\n"
+        "}\n\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_SetAP(FPDF_ANNOTATION annot,"
+    )
+    cpp_new = (
+        "  pAnnotDict->SetNewFor<CPDF_Number>(key, value);\n"
+        "  return true;\n"
+        "}\n\n"
+        + markup_impl
+        + "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_SetAP(FPDF_ANNOTATION annot,"
+    )
+    if f.file_has_content(cpp, cpp_old):
+        f.replace_in_file(cpp, cpp_old, cpp_new)
+        l.bullet("Applied: FPDF BS/RD/BE markup (fpdfsdk/fpdf_annot.cpp)", l.GREEN)
+    else:
+        l.bullet("Skipped: FPDF BS/RD/BE (cpp anchor mismatch)", l.PURPLE)
+        return
+
+    h_old = (
+        "float value);\n\n"
+        "// Experimental API.\n"
+        "// Set the AP (appearance string) in |annot|'s dictionary for a given\n"
+        "// |appearanceMode|.\n"
+        "//\n"
+        "//   annot          - handle to an annotation.\n"
+    )
+    h_new = (
+        "float value);\n\n"
+        "// Experimental API (Lumin). Square / Circle: /BS, /RD, /BE; see patch.py.\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_GetRectDiff(FPDF_ANNOTATION annot, float* outLeft, float* outTop,\n"
+        "                      float* outRight, float* outBottom);\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_SetRectDiff(FPDF_ANNOTATION annot, float left, float top, float right,\n"
+        "                      float bottom);\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_GetBorderStyleDict(FPDF_ANNOTATION annot, char* outS, int sLen,\n"
+        "                            char* outDashComma, int dashCommaLen, float* wOut);\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_SetBorderStyleDict(FPDF_ANNOTATION annot, const char* sName,\n"
+        "                            const char* dashComma, float w);\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_GetBorderEffectDict(FPDF_ANNOTATION annot, char* outS, int sLen,\n"
+        "                            float* iOut);\n"
+        "FPDF_EXPORT FPDF_BOOL FPDF_CALLCONV\n"
+        "FPDFAnnot_SetBorderEffectDict(FPDF_ANNOTATION annot, const char* sName,\n"
+        "                            float intensity);\n"
+        "\n"
+        "// Experimental API.\n"
+        "// Set the AP (appearance string) in |annot|'s dictionary for a given\n"
+        "// |appearanceMode|.\n"
+        "//\n"
+        "//   annot          - handle to an annotation.\n"
+    )
+    if f.file_has_content(header, h_old):
+        f.replace_in_file(header, h_old, h_new)
+        l.bullet("Applied: FPDF BS/RD/BE (public/fpdf_annot.h)", l.GREEN)
+    else:
+        l.bullet(
+            "Warning: FPDF BS/RD/BE cpp done but public header anchor mismatch — add decls by hand",
+            l.PURPLE,
+        )
+
+
+# -----------------------------------------------------------------------------
+def apply_lumin_custom_patches(target):
+    """
+    Idempotent hook for Lumin-specific PDFium source changes.
+
+    Add new patch steps here so they survive `gclient sync` (unlike one-off
+    hand-edits under build/<target>/pdfium/). Call sites: ios.run_task_patch,
+    android.run_task_patch.
+
+    Args:
+        target: "ios" or "android" — use to build paths under build/<target>/pdfium/.
+    """
+    _apply_fpdf_annot_set_color_without_ca(target)
+    _apply_fpdf_annot_interior_color_key_exists(target)
+    _apply_fpdf_annot_object_support_closeshapes(target)
+    _apply_fpdf_annot_line_native_create_and_setline(target)
+    _apply_fpdf_annot_set_number_value(target)
+    _apply_fpdf_annot_line_endings(target)
+    _apply_fpdf_annot_markup_bs_rd_be(target)

--- a/sample-apple/Sample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/sample-apple/Sample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,98 +1,98 @@
 {
-  "images" : [
+  "images": [
     {
-      "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "2x"
+      "idiom": "iphone",
+      "size": "20x20",
+      "scale": "2x"
     },
     {
-      "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "3x"
+      "idiom": "iphone",
+      "size": "20x20",
+      "scale": "3x"
     },
     {
-      "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "idiom": "iphone",
+      "size": "29x29",
+      "scale": "2x"
     },
     {
-      "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "idiom": "iphone",
+      "size": "29x29",
+      "scale": "3x"
     },
     {
-      "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "idiom": "iphone",
+      "size": "40x40",
+      "scale": "2x"
     },
     {
-      "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "idiom": "iphone",
+      "size": "40x40",
+      "scale": "3x"
     },
     {
-      "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "idiom": "iphone",
+      "size": "60x60",
+      "scale": "2x"
     },
     {
-      "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "idiom": "iphone",
+      "size": "60x60",
+      "scale": "3x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "1x"
+      "idiom": "ipad",
+      "size": "20x20",
+      "scale": "1x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "2x"
+      "idiom": "ipad",
+      "size": "20x20",
+      "scale": "2x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "idiom": "ipad",
+      "size": "29x29",
+      "scale": "1x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "idiom": "ipad",
+      "size": "29x29",
+      "scale": "2x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "idiom": "ipad",
+      "size": "40x40",
+      "scale": "1x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "idiom": "ipad",
+      "size": "40x40",
+      "scale": "2x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "idiom": "ipad",
+      "size": "76x76",
+      "scale": "1x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "idiom": "ipad",
+      "size": "76x76",
+      "scale": "2x"
     },
     {
-      "idiom" : "ipad",
-      "size" : "83.5x83.5",
-      "scale" : "2x"
+      "idiom": "ipad",
+      "size": "83.5x83.5",
+      "scale": "2x"
     },
     {
-      "idiom" : "ios-marketing",
-      "size" : "1024x1024",
-      "scale" : "1x"
+      "idiom": "ios-marketing",
+      "size": "1024x1024",
+      "scale": "1x"
     }
   ],
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
+  "info": {
+    "version": 1,
+    "author": "xcode"
   }
 }

--- a/sample-apple/Sample/Assets.xcassets/Contents.json
+++ b/sample-apple/Sample/Assets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
-  "info" : {
-    "version" : 1,
-    "author" : "xcode"
+  "info": {
+    "version": 1,
+    "author": "xcode"
   }
 }

--- a/sample-apple/SampleMac/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/sample-apple/SampleMac/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,11 +1,11 @@
 {
-  "colors" : [
+  "colors": [
     {
-      "idiom" : "universal"
+      "idiom": "universal"
     }
   ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
+  "info": {
+    "author": "xcode",
+    "version": 1
   }
 }

--- a/sample-apple/SampleMac/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/sample-apple/SampleMac/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,58 +1,58 @@
 {
-  "images" : [
+  "images": [
     {
-      "idiom" : "mac",
-      "scale" : "1x",
-      "size" : "16x16"
+      "idiom": "mac",
+      "scale": "1x",
+      "size": "16x16"
     },
     {
-      "idiom" : "mac",
-      "scale" : "2x",
-      "size" : "16x16"
+      "idiom": "mac",
+      "scale": "2x",
+      "size": "16x16"
     },
     {
-      "idiom" : "mac",
-      "scale" : "1x",
-      "size" : "32x32"
+      "idiom": "mac",
+      "scale": "1x",
+      "size": "32x32"
     },
     {
-      "idiom" : "mac",
-      "scale" : "2x",
-      "size" : "32x32"
+      "idiom": "mac",
+      "scale": "2x",
+      "size": "32x32"
     },
     {
-      "idiom" : "mac",
-      "scale" : "1x",
-      "size" : "128x128"
+      "idiom": "mac",
+      "scale": "1x",
+      "size": "128x128"
     },
     {
-      "idiom" : "mac",
-      "scale" : "2x",
-      "size" : "128x128"
+      "idiom": "mac",
+      "scale": "2x",
+      "size": "128x128"
     },
     {
-      "idiom" : "mac",
-      "scale" : "1x",
-      "size" : "256x256"
+      "idiom": "mac",
+      "scale": "1x",
+      "size": "256x256"
     },
     {
-      "idiom" : "mac",
-      "scale" : "2x",
-      "size" : "256x256"
+      "idiom": "mac",
+      "scale": "2x",
+      "size": "256x256"
     },
     {
-      "idiom" : "mac",
-      "scale" : "1x",
-      "size" : "512x512"
+      "idiom": "mac",
+      "scale": "1x",
+      "size": "512x512"
     },
     {
-      "idiom" : "mac",
-      "scale" : "2x",
-      "size" : "512x512"
+      "idiom": "mac",
+      "scale": "2x",
+      "size": "512x512"
     }
   ],
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
+  "info": {
+    "author": "xcode",
+    "version": 1
   }
 }

--- a/sample-apple/SampleMac/Assets.xcassets/Contents.json
+++ b/sample-apple/SampleMac/Assets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
-  "info" : {
-    "author" : "xcode",
-    "version" : 1
+  "info": {
+    "author": "xcode",
+    "version": 1
   }
 }


### PR DESCRIPTION
# Lumin PDFium `fpdfsdk` patches (`patch.py`)

This document explains **what the Lumin patch step does to PDFium’s annotation SDK** (`fpdfsdk/fpdf_annot.cpp` and `public/fpdf_annot.h` in the **build tree**). Patches are **idempotent**: re-running `patch.py` after `gclient sync` should skip work that is already present.

**Implementation:** [`pdfium-lib/modules/patch.py`](../../pdfium-lib/modules/patch.py) — function `apply_lumin_custom_patches(target)` where `target` is `"ios"` or `"android"`.  
**Build output tree:** `pdfium-lib/build/<target>/pdfium/` (not the vendored `ios/Vendor/pdfium.xcframework` copy; those headers are updated when you **publish** a new build).

---

## Why patch at all?

Stock **PDFium** exposes a small, read-oriented FPDF surface for annotations. Lumin needs to:

- Read and write **standard PDF keys** that have no public getter/setter (nested dicts, line array `/L`, opacity write, etc.).
- Treat **Square** and **Circle** like Ink for **form-object** appearance editing (custom dashed/cloudy paths).
- Distinguish **missing** `/C` or `/IC` from **default** colors returned by `FPDFAnnot_GetColor`.

The patches add **experimental, Lumin-prefixed** APIs (documented in the public header as experimental) implemented in `fpdf_annot.cpp` using the same internal helpers PDFium uses (`GetMutableAnnotDictFromFPDFAnnotation`, `CPDF_Dictionary`, etc.).

---

## Apply order (`apply_lumin_custom_patches`)

Steps run **in this order** (some later steps **depend** on earlier ones):

| # | Patch function | Adds / changes (summary) |
|---|----------------|-------------------------|
| 1 | `_apply_fpdf_annot_set_color_without_ca` | **`FPDFAnnot_SetColorWithoutCA`** — set or remove `/C` / `/IC` **without** writing annotation **`/CA`**, and keep the dict consistent when a Normal `/AP` exists. Upgrades may exist for older Lumin variants (see `patch.py`). |
| 2 | `_apply_fpdf_annot_interior_color_key_exists` | **`FPDFAnnot_AnnotationColorDictionaryKeyExists`**, **`FPDFAnnot_StrokeColorDictionaryKeyExists`**, **`FPDFAnnot_InteriorColorDictionaryKeyExists`** — true if `/C` or `/IC` **key exists** (so export does not treat `GetColor` defaults as real authored colors). |
| 3 | `_apply_fpdf_annot_object_support_closeshapes` | **`FPDFAnnot_IsObjectSupportedSubtype`** — include **`FPDF_ANNOT_SQUARE`** and **`FPDF_ANNOT_CIRCLE`** so `FPDFAnnot_GetObject` / `AppendObject` / `UpdateObject` work for custom closed-shape `/AP` (dashed, cloudy), not only Ink/Stamp. Public header comments updated. |
| 4 | `_apply_fpdf_annot_line_native_create_and_setline` | **Native Line:** extend **`FPDFAnnot_IsSupportedSubtype`** with **`FPDF_ANNOT_LINE`** (allow `FPDFPage_CreateAnnot`); extend **`IsObjectSupportedSubtype`** for Line form objects; add **`FPDFAnnot_SetLine`** to write **`/L`**. Stock PDFium only had `GetLine` (read). |
| 5 | `_apply_fpdf_annot_set_number_value` | **`FPDFAnnot_SetNumberValue`** — set an arbitrary number in the annot dict (e.g. **`/CA`** opacity, object numbers). |
| 6 | `_apply_fpdf_annot_line_endings` | **`FPDFAnnot_GetLineEndings`** / **`FPDFAnnot_SetLineEndings`** — read/write ISO **`/LE`** (two **name** entries) for **Line** and **Polyline**. Inserts after `SetLine` (requires step 4). Also runs **`_apply_fpdf_annot_line_endings_polyline_upgrade`** to allow polyline and remove legacy `LMLE1` cleanup if present. |
| 7 | `_apply_fpdf_annot_markup_bs_rd_be` | **Square/Circle markup:** insert implementation from [`lumin_markup_bs_rd_be.cpp.inc`](../../pdfium-lib/modules/lumin_markup_bs_rd_be.cpp.inc) and public declarations: **`FPDFAnnot_Get/SetRectDiff`** (`/RD`), **`Get/SetBorderStyleDict`** (`/BS`), **`Get/SetBorderEffectDict`** (`/BE`). **Anchors after** `FPDFAnnot_SetNumberValue` (step 5) and **before** `FPDFAnnot_SetAP`. |

---

## Bodies pulled from separate files

- **Markup `/BS` / `/RD` / `/BE`:** C++ text is read from `pdfium-lib/modules/lumin_markup_bs_rd_be.cpp.inc` and injected into `fpdf_annot.cpp` so the large block stays maintainable and reviewable outside the Python string literals.

---

## Other patch entry points (not `fpdf_annot` logic)

`patch.py` also includes:

- **`apply_shared_library`** — switches the GN `pdfium` target from `component` to **`shared_library`** (Android/iOS build expectations).
- **`apply_public_headers`** — strips `COMPONENT_BUILD` / `FPDF_EXPORT` conditionals in **`public/fpdfview.h`** so the published headers match how Lumin links the library.

These are **build / linkage** concerns, not annotation behaviour.

---

## Lumin C++ / iOS / Android consumers (pointers)

| API area | Typical consumer |
|----------|------------------|
| `SetColorWithoutCA`, stroke/interior key exists | `cpp/core/PDFiumAnnotation.*`, `xfdf/*` export, iOS color plumbing |
| Square/Circle form objects | `cpp/xfdf/square/SquareAnnotation.cpp`, `Lumin_rebuild*`, style picker |
| `SetLine`, `Get/SetLineEndings` | `cpp/xfdf/line/LineAnnotation.cpp`, polyline |
| `SetNumberValue` | Opacity `/CA` (`LineAnnotation`, etc.) |
| Markup `BS`/`RD`/`BE` | `cpp/xfdf/LuminFPDFAnnotMarkup.h`, `LuminFPDFAnnotMarkupFieldIO.*` |

---

## Adding a new patch

1. Add a new `_apply_fpdf_annot_*` function in `patch.py` with **stable anchors** (unique strings) so the replace is idempotent.  
2. Call it from `apply_lumin_custom_patches` in the right **order** (respect dependencies).  
3. Rebuild PDFium for iOS and Android, then refresh vendored headers / `xcframework` per your pipeline.  
